### PR TITLE
feat(web): add state filter to politician listing (RF-003)

### DIFF
--- a/apps/web/src/app/politicos/page.tsx
+++ b/apps/web/src/app/politicos/page.tsx
@@ -5,6 +5,7 @@ import { Suspense } from 'react'
 import { fetchPoliticians } from '../../lib/api-client'
 import { PoliticianCard } from '../../components/politician/politician-card'
 import { RoleFilter } from '../../components/filters/role-filter'
+import { StateFilter } from '../../components/filters/state-filter'
 import type { Metadata } from 'next'
 import type { PoliticianFilters } from '@pah/shared'
 import Link from 'next/link'
@@ -25,17 +26,20 @@ export default async function PoliticosPage({ searchParams }: Props): Promise<Re
   const params = await searchParams
   const cursor = typeof params['cursor'] === 'string' ? params['cursor'] : undefined
   const role = typeof params['role'] === 'string' ? params['role'] : undefined
+  const state = typeof params['state'] === 'string' ? params['state'] : undefined
 
   // exactOptionalPropertyTypes: build filters object conditionally (no undefined spreads)
   const filters: PoliticianFilters = {}
   if (cursor !== undefined) filters.cursor = cursor
   if (role !== undefined) filters.role = role as 'deputado' | 'senador'
+  if (state !== undefined) filters.state = state
 
   const result = await fetchPoliticians(filters)
 
-  // Build base params for pagination links (preserves role, excludes cursor)
+  // Build base params for pagination links (preserves role + state, excludes cursor)
   const baseParams = new URLSearchParams()
   if (role !== undefined) baseParams.set('role', role)
+  if (state !== undefined) baseParams.set('state', state)
 
   return (
     <main className="container mx-auto px-4 py-8">
@@ -45,6 +49,9 @@ export default async function PoliticosPage({ searchParams }: Props): Promise<Re
       <div className="mb-6 flex items-center gap-4">
         <Suspense fallback={<div className="h-10 w-48 animate-pulse rounded-md bg-muted" />}>
           <RoleFilter />
+        </Suspense>
+        <Suspense fallback={<div className="h-10 w-36 animate-pulse rounded-md bg-muted" />}>
+          <StateFilter />
         </Suspense>
       </div>
 

--- a/apps/web/src/components/filters/state-filter.test.tsx
+++ b/apps/web/src/components/filters/state-filter.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { useSearchParams, useRouter } from 'next/navigation'
+import type { ReadonlyURLSearchParams } from 'next/navigation'
+import type { AppRouterInstance } from 'next/dist/shared/lib/app-router-context.shared-runtime'
+import { StateFilter } from './state-filter'
+
+// helpers to satisfy strict types from next/navigation mocks
+const mockSearchParams = (init?: string): ReadonlyURLSearchParams =>
+  new URLSearchParams(init) as unknown as ReadonlyURLSearchParams
+
+const mockRouter = (push: ReturnType<typeof vi.fn>): AppRouterInstance =>
+  ({ push, prefetch: vi.fn(), back: vi.fn(), forward: vi.fn(), refresh: vi.fn(), replace: vi.fn() }) as AppRouterInstance
+
+describe('StateFilter', () => {
+  it('renders select with 28 options (Todos + 27 UFs)', () => {
+    render(<StateFilter />)
+    expect(screen.getByRole('combobox', { name: /filtrar por estado/i })).toBeInTheDocument()
+    const options = screen.getAllByRole('option')
+    expect(options).toHaveLength(28)
+    expect(screen.getByRole('option', { name: 'Todos os estados' })).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: 'SP' })).toBeInTheDocument()
+  })
+
+  it('defaults to empty (Todos os estados) when no state in URL', () => {
+    render(<StateFilter />)
+    const select = screen.getByRole('combobox', { name: /filtrar por estado/i })
+    expect((select as HTMLSelectElement).value).toBe('')
+  })
+
+  it('shows SP as selected when state=SP in URL', () => {
+    vi.mocked(useSearchParams).mockReturnValueOnce(mockSearchParams('state=SP'))
+    render(<StateFilter />)
+    const select = screen.getByRole('combobox', { name: /filtrar por estado/i })
+    expect((select as HTMLSelectElement).value).toBe('SP')
+  })
+
+  it('calls router.push with state param and clears cursor on change', () => {
+    const pushMock = vi.fn()
+    vi.mocked(useRouter).mockReturnValueOnce(mockRouter(pushMock))
+    // Simulate existing cursor in URL so we can verify it's cleared
+    vi.mocked(useSearchParams).mockReturnValueOnce(mockSearchParams('cursor=abc123'))
+
+    render(<StateFilter />)
+    fireEvent.change(screen.getByRole('combobox', { name: /filtrar por estado/i }), {
+      target: { value: 'RJ' },
+    })
+
+    expect(pushMock).toHaveBeenCalledWith('/politicos?state=RJ')
+  })
+
+  it('removes state param from URL when Todos os estados is selected', () => {
+    const pushMock = vi.fn()
+    vi.mocked(useRouter).mockReturnValueOnce(mockRouter(pushMock))
+    vi.mocked(useSearchParams).mockReturnValueOnce(mockSearchParams('state=SP'))
+
+    render(<StateFilter />)
+    fireEvent.change(screen.getByRole('combobox', { name: /filtrar por estado/i }), {
+      target: { value: '' },
+    })
+
+    expect(pushMock).toHaveBeenCalledWith('/politicos')
+  })
+})

--- a/apps/web/src/components/filters/state-filter.tsx
+++ b/apps/web/src/components/filters/state-filter.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import { useSearchParams, useRouter, usePathname } from 'next/navigation'
+import { useCallback } from 'react'
+
+const STATE_OPTIONS = [
+  { value: '', label: 'Todos os estados' },
+  { value: 'AC', label: 'AC' },
+  { value: 'AL', label: 'AL' },
+  { value: 'AM', label: 'AM' },
+  { value: 'AP', label: 'AP' },
+  { value: 'BA', label: 'BA' },
+  { value: 'CE', label: 'CE' },
+  { value: 'DF', label: 'DF' },
+  { value: 'ES', label: 'ES' },
+  { value: 'GO', label: 'GO' },
+  { value: 'MA', label: 'MA' },
+  { value: 'MG', label: 'MG' },
+  { value: 'MS', label: 'MS' },
+  { value: 'MT', label: 'MT' },
+  { value: 'PA', label: 'PA' },
+  { value: 'PB', label: 'PB' },
+  { value: 'PE', label: 'PE' },
+  { value: 'PI', label: 'PI' },
+  { value: 'PR', label: 'PR' },
+  { value: 'RJ', label: 'RJ' },
+  { value: 'RN', label: 'RN' },
+  { value: 'RO', label: 'RO' },
+  { value: 'RR', label: 'RR' },
+  { value: 'RS', label: 'RS' },
+  { value: 'SC', label: 'SC' },
+  { value: 'SE', label: 'SE' },
+  { value: 'SP', label: 'SP' },
+  { value: 'TO', label: 'TO' },
+] as const
+
+export function StateFilter(): React.JSX.Element {
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLSelectElement>): void => {
+      const params = new URLSearchParams(searchParams.toString())
+      if (e.target.value !== '') {
+        params.set('state', e.target.value)
+      } else {
+        params.delete('state')
+      }
+      params.delete('cursor') // always reset pagination on filter change
+      const qs = params.toString()
+      router.push(qs !== '' ? `${pathname}?${qs}` : pathname)
+    },
+    [router, pathname, searchParams],
+  )
+
+  return (
+    <div className="flex items-center gap-2">
+      <label htmlFor="state-filter" className="text-sm font-medium text-foreground">
+        Estado:
+      </label>
+      <select
+        id="state-filter"
+        value={searchParams.get('state') ?? ''}
+        onChange={handleChange}
+        aria-label="Filtrar por estado"
+        className="rounded-md border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+      >
+        {STATE_OPTIONS.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Implement the state (UF) filter for the `/politicos` politician listing page as Phase 3 of the PRD. This adds a dropdown filter allowing users to narrow politicians by Brazilian state, complementing the existing role filter.

## Changes

- **`state-filter.tsx`** — New Client Component mirroring the `RoleFilter` pattern with 28 options (Todos os estados + 27 UF codes). Uses URL search params for state management, clears cursor on filter change.
- **`state-filter.test.tsx`** — 5 unit tests covering: render count (28 options), default value, pre-selected value, router.push on change, parameter removal.
- **`politicos/page.tsx`** — Extract `state` from searchParams, add to filters object and baseParams (preserves both `role` and `state` in pagination links), import and wire `StateFilter` in Suspense wrapper.

## Files Changed

3 files changed, 149 insertions(+)

- `apps/web/src/components/filters/state-filter.tsx` (new)
- `apps/web/src/components/filters/state-filter.test.tsx` (new)
- `apps/web/src/app/politicos/page.tsx` (updated)

## Testing

- [x] TypeScript typecheck passes (`pnpm typecheck`)
- [x] All 16 tests pass: 11 existing + 5 new (`pnpm test`)
- [x] ESLint passes (`pnpm lint`)
- [x] Next.js build succeeds (`pnpm build`)
- [x] Full workspace validation passes (`pnpm typecheck && pnpm test`)

## Design Notes

- **Political Neutrality**: 27 UF codes listed alphabetically with no editorializing (DR-002)
- **URL as State**: Filters preserved in pagination links via `baseParams` (both role + state)
- **Accessibility**: Proper `aria-label` and `htmlFor` associations; Tailwind focus styles
- **Pattern Consistency**: Exact mirror of Phase 2 `RoleFilter` implementation for maintainability

## Related PRs

- Phase 1: RF-001 (merged via #1)
- Phase 2: RF-002 (merged via #1)
- Phase 3: RF-003 (this PR)

Backend is fully implemented for state filtering (all 7 layers: types, client, schema, route, service, repository, database). This PR wires the frontend UI.