### PR TITLE
feat(prd): evolve to v1.1 — frontend security-first principle

### DIFF
--- a/.claude/PRPs/prds/rf-mvp-remaining-features.prd.md
+++ b/.claude/PRPs/prds/rf-mvp-remaining-features.prd.md
@@ -175,6 +175,7 @@ Researchers needing bulk data export (post-MVP API), users wanting comparison fe
 | 7 | Data Ingestion Pipeline (RF-013) | Bootstrap pipeline app, 6 source adapters, pg-boss scheduler, internal schema | pending | - | - | - |
 | 8 | Scoring + Anti-Corruption + Freshness (RF-004, RF-006, RF-014) | Scoring engine, exclusion detection, data_source_status, /fontes page | pending | - | 7 | - |
 | 9 | SEO + Responsive Polish (RF-017, RF-016) | generateMetadata() per profile, JSON-LD, sitemap.xml, robots.txt, mobile audit | pending | - | 2,6 | - |
+| 10 | Frontend Security Hardening (DR-008) | CSP header, server-only guards, ESLint restrictions, CI bundle scan, pnpm audit (RNF-SEC-011,012,014,017) | pending | with 5 | - | - |
 
 ### Phase Details
 
@@ -245,6 +246,20 @@ Researchers needing bulk data export (post-MVP API), users wanting comparison fe
   - RF-017: `generateMetadata()` in `/politicos/[slug]/page.tsx` with dynamic `og:title`, `og:description`, `og:image` (politician photo URL), canonical URL. JSON-LD `Person` schema component. `sitemap.xml` route at `/sitemap.xml` (dynamic, reads all slugs from API). `robots.txt` at `/robots.txt` (static, allows all). All pages: unique titles, unique descriptions.
   - RF-016: Full viewport audit 320px–2560px across all pages. Verify 44×44px tap targets on all interactive elements. Fix any horizontal overflow on mobile. Stack profile section tabs vertically on mobile.
 - **Depends on:** Phases 2 and 6 (all profile pages must exist before SEO can be applied)
+
+**Phase 10: Frontend Security Hardening (DR-008)**
+
+- **Goal:** Apply the security-first principle (PRD v1.1) to all existing and future frontend code
+- **Scope:**
+  - **CSP Header (RNF-SEC-011):** Add full `Content-Security-Policy-Report-Only` header to `next.config.ts` via `headers()` function. Policy: `default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data: https:; font-src 'self'; connect-src 'self' {NEXT_PUBLIC_API_URL}; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests`.
+  - **`server-only` guards (RNF-SEC-012):** Add `import 'server-only'` to `packages/db/src/public-schema.ts`, `internal-schema.ts`, `clients.ts`, and `migrate.ts`. Install `server-only` as a dependency of `@pah/db`.
+  - **ESLint restrictions (RNF-SEC-012):** Add `no-restricted-imports` rule to `apps/web/.eslintrc.cjs` forbidding `@pah/db`, `pg`, `drizzle-orm`, `pg-boss`.
+  - **CI bundle scan (RNF-SEC-017):** Add `pnpm audit --audit-level=high` step and post-build forbidden-pattern grep to `.github/workflows/ci.yml` (per project-cicd skill Security CI Steps).
+  - **Error sanitization verification (RNF-SEC-014):** Audit existing `error.tsx` and `api-client.ts` to confirm no internal details leak. The existing implementations already comply; this is a verification task.
+- **DB changes:** None
+- **Success signal:** `next build` fails if any Client Component imports `@pah/db`. CI fails on high vulnerabilities. CI fails if `drizzle-orm` or `DATABASE_URL` appear in `.next/static/chunks/`. CSP header visible in browser DevTools Network tab.
+- **Parallel with:** Phase 5 (completely independent — config and tooling only, no feature code)
+- **Note:** Phase 7 pipeline must also implement HTML stripping of government source text in transformers (RNF-SEC-013) when built.
 
 ### Parallelism Notes
 

--- a/.claude/skills/project-cicd/SKILL.md
+++ b/.claude/skills/project-cicd/SKILL.md
@@ -16,13 +16,14 @@ Maintains a **lean** GitHub Actions pipeline at `.github/workflows/ci.yml`. The 
 | Tool | Version | CI Step | Why It's Here |
 |------|---------|---------|---------------|
 | pnpm | 9 | Install | Workspace package manager |
-| Node.js | 20 | Setup | Fastify 5 requires ≥20 |
+| Node.js | 20 | Setup | Fastify 5 requires >=20 |
 | Turborepo | 2 (via pnpm) | All steps | Monorepo orchestration |
 | ESLint | (via root `.eslintrc.cjs`) | Lint | Catches import boundary violations |
 | TypeScript | 5.4 | Typecheck | `exactOptionalPropertyTypes`, `noUncheckedIndexedAccess` |
 | Vitest | 2 | Unit tests | Fast unit tests, no external deps |
 | Next.js | 15 | Build | SSG/ISR build verification |
 | Fastify | 5 | Build | Included via `pnpm build` |
+| pnpm audit | (via pnpm) | Security audit | Catches high/critical dependency vulnerabilities |
 
 ---
 
@@ -30,11 +31,10 @@ Maintains a **lean** GitHub Actions pipeline at `.github/workflows/ci.yml`. The 
 
 | Tool/Task | Reason Excluded |
 |-----------|----------------|
-| Integration tests (`*.integration.test.ts`) | Require a live PostgreSQL instance — use Testcontainers. Not yet written; add when the first integration test exists and add a `services: postgres` job. |
+| Integration tests (`*.integration.test.ts`) | Require a live PostgreSQL instance -- use Testcontainers. Not yet written; add when the first integration test exists and add a `services: postgres` job. |
 | E2E tests (Playwright `e2e/*.spec.ts`) | No E2E tests written yet. Add when first spec exists, with a separate job that starts the dev server. |
 | Docker build | Production concern, not CI correctness. Add to a separate `deploy.yml` workflow. |
 | Coverage reporting | Adds 10-20s with no quality gate yet defined. Add when coverage targets are set. |
-| `npm audit` / `pnpm audit` | High false-positive rate in monorepos. Run manually when adding dependencies. |
 | Lighthouse CI | Requires a live URL. Add to `deploy.yml` after deployment. |
 | Database migrations | No live DB in CI. Validated by typecheck via Drizzle schema types. |
 
@@ -50,20 +50,21 @@ Ask: "What does this tool verify that isn't already covered?"
 
 | Category | Example | CI-worthy? |
 |----------|---------|------------|
-| Linter/formatter | Prettier, Biome | YES — catches style drift |
-| Type checker | tsc, pyright | YES — catches type errors at PR time |
-| Unit test runner | Vitest, Jest, pytest | YES — must run on every PR |
-| Build tool | Next.js build, tsc --build | YES — confirms production artifact |
-| Infrastructure provisioning | Terraform, Pulumi | NO — goes in deploy.yml, not CI |
-| Database migration | drizzle-kit migrate | NO — needs live DB; not in unit CI |
+| Linter/formatter | Prettier, Biome | YES -- catches style drift |
+| Type checker | tsc, pyright | YES -- catches type errors at PR time |
+| Unit test runner | Vitest, Jest, pytest | YES -- must run on every PR |
+| Build tool | Next.js build, tsc --build | YES -- confirms production artifact |
+| Infrastructure provisioning | Terraform, Pulumi | NO -- goes in deploy.yml, not CI |
+| Database migration | drizzle-kit migrate | NO -- needs live DB; not in unit CI |
 | E2E test runner | Playwright, Cypress | YES, but only after first spec exists |
-| Container build | Docker, kaniko | NO — build time cost; goes in deploy.yml |
-| Security scanner | Snyk, trivy | MAYBE — add only if required by team policy |
-| Coverage upload | codecov, coveralls | MAYBE — add only after coverage targets defined |
+| Container build | Docker, kaniko | NO -- build time cost; goes in deploy.yml |
+| Security scanner | Snyk, trivy | MAYBE -- add only if required by team policy |
+| Coverage upload | codecov, coveralls | MAYBE -- add only after coverage targets defined |
 
 ### Step 2: Check the cost
 
 Before adding, estimate:
+
 - Does this add more than 60s to the total CI time? If yes, consider a separate parallel job.
 - Does this require a service (database, Redis, network)? If yes, it cannot go in the simple job.
 - Does this require secrets? Add to `env:` block only if the step cannot run without them.
@@ -73,7 +74,7 @@ Before adding, estimate:
 Add the step in this order within the single job:
 
 ```
-checkout → setup tools → install → lint → typecheck → test → build
+checkout -> setup tools -> install -> lint -> typecheck -> test -> build -> security
 ```
 
 If the tool needs a separate job (e.g., integration tests with PostgreSQL service):
@@ -128,11 +129,13 @@ When the first `*.integration.test.ts` file is created:
 1. Add a `services: postgres:16-alpine` block to a new `integration` job
 2. Add `DATABASE_URL` env var pointing to the service
 3. Change the unit test step to explicitly exclude integration tests:
+
    ```yaml
    - name: Unit tests
      run: pnpm test --reporter=verbose
    ```
-   (Vitest already excludes `*.integration.test.ts` via `vitest.config.ts` `exclude` pattern — verify this is configured)
+
+   (Vitest already excludes `*.integration.test.ts` via `vitest.config.ts` `exclude` pattern -- verify this is configured)
 4. Update this skill's table
 
 ## When E2E Tests Are Added
@@ -147,6 +150,45 @@ When the first `e2e/*.spec.ts` file is created:
 
 ---
 
+## Security CI Steps
+
+These steps enforce the Frontend Security First principle (DR-008, RNF-SEC-017):
+
+### Step 1: Dependency Audit
+
+```yaml
+- name: Security audit
+  run: pnpm audit --audit-level=high
+  continue-on-error: false
+```
+
+Runs `pnpm audit` with `--audit-level=high` threshold. Fails the build on high or critical vulnerabilities.
+
+### Step 2: Client Bundle Leak Scan (post-build)
+
+After `pnpm build`, scan client chunks for forbidden patterns:
+
+```yaml
+- name: Client bundle security scan
+  run: |
+    FORBIDDEN="drizzle-orm|@pah/db|public-schema|internal-schema|DATABASE_URL|CPF_ENCRYPTION_KEY|TRANSPARENCIA_API_KEY|VERCEL_REVALIDATE_TOKEN"
+    if grep -rEl "$FORBIDDEN" apps/web/.next/static/chunks/ 2>/dev/null; then
+      echo "::error::Forbidden patterns found in client bundle!"
+      exit 1
+    fi
+```
+
+Detects server-only modules and secret variable names that should never appear in client JavaScript.
+
+### Step 3: Secret Pattern Pre-commit
+
+Enforced via lint-staged hook (not CI), but documented here:
+
+- Regex patterns: `/\d{3}\.?\d{3}\.?\d{3}-?\d{2}/` (CPF format), `/(password|secret|token)\s*[:=]\s*['"][^'"]+/i`
+- Scans only staged `.ts`, `.tsx`, `.js`, `.json`, `.env*` files
+
+---
+
 ## Leanness Checklist
 
 Before every `ci.yml` change, verify:
@@ -158,3 +200,12 @@ Before every `ci.yml` change, verify:
 - [ ] If it needs a service, it's in a separate job with `needs: ci`
 
 The default answer to "should I add this?" is **no**. Add only when the answer to "what real bug has this caught that we'd want to catch automatically?" has a clear answer.
+
+---
+
+## Changelog
+
+| Date | PRD Version | Summary |
+|------|-------------|---------|
+| 2026-02-28 | 1.0 | Initial CI/CD maintenance skill |
+| 2026-03-07 | 1.1 | Add pnpm audit to CI stack, add Security CI Steps section (DR-008, RNF-SEC-017), remove pnpm audit from exclusions |

--- a/.claude/skills/project-compliance/SKILL.md
+++ b/.claude/skills/project-compliance/SKILL.md
@@ -81,6 +81,7 @@ Enforces compliance with Brazilian data protection and transparency laws applica
 ### G. Data Subject Rights (Art. 18)
 
 If user registration is added post-MVP:
+
 - [ ] Right to access: users can view their data
 - [ ] Right to correction: users can update their data
 - [ ] Right to deletion: users can delete their account
@@ -101,8 +102,8 @@ If user registration is added post-MVP:
 
 ### Respect API Terms
 
-- [ ] Portal da Transparência rate limits respected: 90 req/min (peak), 300 req/min (off-peak)
-- [ ] API key used as required by Portal da Transparência
+- [ ] Portal da Transparencia rate limits respected: 90 req/min (peak), 300 req/min (off-peak)
+- [ ] API key used as required by Portal da Transparencia
 - [ ] No scraping of HTML pages when APIs are available
 - [ ] Bulk CSV downloads used for large datasets (TSE, CGU-PAD)
 
@@ -144,7 +145,7 @@ If user registration is added post-MVP:
 ### Secret Management
 
 - [ ] Database passwords in environment variables, never in code
-- [ ] Portal da Transparência API key in environment variable
+- [ ] Portal da Transparencia API key in environment variable
 - [ ] CPF encryption key in environment variable
 - [ ] No secrets in git history (`git log -p -- '*.env*'` returns nothing)
 - [ ] `.env` files in `.gitignore`
@@ -158,6 +159,20 @@ If user registration is added post-MVP:
 - [ ] No superuser credentials in application code
 - [ ] Database not exposed to public internet (Docker internal network)
 - [ ] Encrypted connections to database (sslmode=require)
+
+### Frontend Security Baseline
+
+- [ ] Content-Security-Policy header configured in `next.config.ts` headers() (RNF-SEC-011)
+- [ ] CSP deployed as `Content-Security-Policy-Report-Only` initially, then enforced after validation
+- [ ] CSP policy: `default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data: https:; font-src 'self'; connect-src 'self' {API_URL}; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests`
+- [ ] `server-only` package installed and imported in all `packages/db/src/` modules
+- [ ] ESLint `no-restricted-imports` forbids `@pah/db`, `pg`, `drizzle-orm` in `apps/web/`
+- [ ] CI post-build scan: grep `.next/static/chunks/` for forbidden patterns
+- [ ] Only `NEXT_PUBLIC_API_URL` uses `NEXT_PUBLIC_` prefix
+- [ ] All `error.tsx` boundaries show generic messages only
+- [ ] Pipeline transformers strip HTML tags from government source text before storing in `public_data`
+- [ ] No external scripts without SRI attributes
+- [ ] Future auth implementation: httpOnly Secure SameSite=Strict cookies, CSRF protection, RS256 JWT, <=24h session
 
 ### Backup and Recovery
 
@@ -180,6 +195,8 @@ If user registration is added post-MVP:
 | CPF leakage check | Every PR (automated) |
 | Backup restore test | Monthly |
 | SSL certificate validity | Automated (Caddy) |
+| Frontend CSP validation | Every deploy (CI) |
+| Client bundle leak scan | Every build (CI) |
 
 ---
 
@@ -188,3 +205,4 @@ If user registration is added post-MVP:
 | Date | PRD Version | Summary |
 |------|-------------|---------|
 | 2026-02-28 | 1.0 | Initial compliance enforcement skill |
+| 2026-03-07 | 1.1 | Add Frontend Security Baseline section |

--- a/.claude/skills/project-domain-rules/SKILL.md
+++ b/.claude/skills/project-domain-rules/SKILL.md
@@ -7,7 +7,7 @@ description: Domain rule enforcement for Political Authority Highlighter. Use wh
 
 ## Purpose
 
-Enforces the 7 domain rules (DR-001 through DR-007) that define the core business invariants of the platform. These rules are NON-NEGOTIABLE.
+Enforces the 8 domain rules (DR-001 through DR-008) that define the core business invariants of the platform. These rules are NON-NEGOTIABLE.
 
 ---
 
@@ -16,6 +16,7 @@ Enforces the 7 domain rules (DR-001 through DR-007) that define the core busines
 **Rule:** Politicians with active corruption indicators are silently excluded from ALL public-facing queries. The platform NEVER indicates that a politician was excluded or WHY they are absent.
 
 ### Code Review Checklist
+
 - [ ] No API endpoint returns `exclusion_records` or `corruption_indicator` fields
 - [ ] No API error message mentions exclusion (e.g., "politician excluded due to...")
 - [ ] No UI element shows "X politicians excluded" or similar counts
@@ -25,6 +26,7 @@ Enforces the 7 domain rules (DR-001 through DR-007) that define the core busines
 - [ ] Search results respect exclusion (excluded politicians never appear)
 
 ### Anti-patterns to REJECT
+
 ```typescript
 // BAD: Leaks exclusion status
 return { politician, isExcluded: true, reason: "CEIS sanction" }
@@ -43,6 +45,7 @@ return { total: 513, excluded: 47, visible: 466 }
 **Rule:** The platform must NEVER exhibit political bias. Score methodology is identical across all parties, roles, and states. No editorializing.
 
 ### Code Review Checklist
+
 - [ ] Score algorithm has NO party-specific logic (no `if party === 'PT'`)
 - [ ] Score weights are the same for all politicians regardless of party/state/role
 - [ ] UI uses neutral colors (no red/blue party associations)
@@ -52,6 +55,7 @@ return { total: 513, excluded: 47, visible: 466 }
 - [ ] No "recommended" or "featured" politician sections
 
 ### Anti-patterns to REJECT
+
 ```typescript
 // BAD: Party-specific scoring
 if (politician.party === 'PSOL') score += 10
@@ -73,6 +77,7 @@ if (politician.party === 'PSOL') score += 10
 **Rule:** Every data point displayed and every score input must originate from a publicly available, verifiable government source.
 
 ### Code Review Checklist
+
 - [ ] Every database record has a `source_url` or `source_id` field
 - [ ] Ingestion pipeline only fetches from whitelisted URLs
 - [ ] No manual data entry forms for politician records
@@ -80,11 +85,12 @@ if (politician.party === 'PSOL') score += 10
 - [ ] Score inputs are traceable to specific API endpoints or CSV datasets
 
 ### Whitelisted Sources
+
 | Source | Domain |
 |--------|--------|
-| Câmara dos Deputados | `dadosabertos.camara.leg.br` |
+| Camara dos Deputados | `dadosabertos.camara.leg.br` |
 | Senado Federal | `legis.senado.leg.br` |
-| Portal da Transparência | `api.portaldatransparencia.gov.br` |
+| Portal da Transparencia | `api.portaldatransparencia.gov.br` |
 | TSE | `dadosabertos.tse.jus.br`, `cdn.tse.jus.br` |
 | TCU | `dados-abertos.apps.tcu.gov.br`, `contas.tcu.gov.br` |
 | CGU | `dadosabertos-download.cgu.gov.br` |
@@ -96,6 +102,7 @@ if (politician.party === 'PSOL') score += 10
 **Rule:** A politician's maximum achievable score is proportional to available public data. Less data = lower ceiling. Zero data = score of 0.
 
 ### Code Review Checklist
+
 - [ ] Score formula includes `data_coverage_ratio` multiplier
 - [ ] `data_coverage_ratio = data_points_found / data_points_expected_for_role`
 - [ ] A politician with no data gets score = 0 (not null, not "N/A")
@@ -103,6 +110,7 @@ if (politician.party === 'PSOL') score += 10
 - [ ] Coverage ratio is stored and displayed for transparency
 
 ### Formula Verification
+
 ```
 final_score = raw_dimensional_score * data_coverage_ratio
 
@@ -119,6 +127,7 @@ Where:
 **Rule:** CPF numbers must NEVER appear in any public-facing interface, API response, URL, or accessible log.
 
 ### Code Review Checklist
+
 - [ ] No CPF in API response bodies (check TypeBox response schemas)
 - [ ] No CPF in URL query parameters or path segments
 - [ ] No CPF in frontend source code or environment variables
@@ -128,7 +137,9 @@ Where:
 - [ ] Encryption key is an environment variable, never in code
 
 ### Detection Patterns
+
 Search for these patterns and REJECT if found in public-facing code:
+
 ```
 /\d{3}\.?\d{3}\.?\d{3}-?\d{2}/  # CPF format
 /cpf/i                            # CPF variable names (in API/frontend)
@@ -142,6 +153,7 @@ Search for these patterns and REJECT if found in public-facing code:
 **Rule:** The platform must not enable retaliation or persecution. It highlights positives; it does not expose negatives.
 
 ### Code Review Checklist
+
 - [ ] No "worst politicians" or "bottom scores" feature
 - [ ] No ascending sort by score (lowest first) in any endpoint or UI
 - [ ] No "corruption details" page or section
@@ -150,6 +162,7 @@ Search for these patterns and REJECT if found in public-facing code:
 - [ ] Platform messaging emphasizes "highlighting integrity" not "exposing corruption"
 
 ### Anti-patterns to REJECT
+
 ```typescript
 // BAD: Reverse sorting enables hit lists
 orderBy: asc(integrityScores.overallScore)
@@ -168,6 +181,7 @@ orderBy: asc(integrityScores.overallScore)
 **Rule:** Running the same ingestion job twice with the same data produces the same database state. Partial failures must not corrupt existing data.
 
 ### Code Review Checklist
+
 - [ ] All inserts use `ON CONFLICT DO UPDATE` (upsert) with natural keys
 - [ ] Ingestion wrapped in database transactions
 - [ ] Failed jobs roll back entirely (no partial state)
@@ -175,6 +189,7 @@ orderBy: asc(integrityScores.overallScore)
 - [ ] Natural keys defined per entity (source + external_id)
 
 ### Pattern
+
 ```typescript
 // GOOD: Idempotent upsert
 await db.insert(politicians)
@@ -190,8 +205,46 @@ await db.insert(politicians).values(data) // Fails on duplicate, or creates dupl
 
 ---
 
+## DR-008: FrontendSecurityFirstInvariant
+
+**Rule:** The frontend layer must never be a vector for data exposure, injection, or trust boundary violation.
+
+### Code Review Checklist
+
+- [ ] No `@pah/db`, `pg`, `drizzle-orm`, `pg-boss` imports in any `apps/web/` file
+- [ ] No `NEXT_PUBLIC_` environment variables except `NEXT_PUBLIC_API_URL`
+- [ ] CSP header defined in `next.config.ts` via `headers()` function
+- [ ] `import 'server-only'` present in `packages/db/src/public-schema.ts`, `internal-schema.ts`, `clients.ts`, `migrate.ts`
+- [ ] All government-sourced text rendered via JSX auto-escaping (never innerHTML)
+- [ ] `dangerouslySetInnerHTML` used ONLY for JSON-LD `<script type="application/ld+json">` with `JSON.stringify()` data
+- [ ] Error boundaries (`error.tsx`) show generic messages -- no stack traces, no DB table names, no internal URLs
+- [ ] No external `<script>` tags without `integrity` and `crossorigin` attributes
+- [ ] API error responses from `api-client.ts` do not expose raw error body to users
+
+### Anti-patterns to REJECT
+
+```typescript
+// BAD: Importing database module in frontend
+import { politicians } from '@pah/db/public-schema'
+
+// BAD: Exposing secrets via NEXT_PUBLIC_
+NEXT_PUBLIC_DATABASE_URL=postgres://...
+
+// BAD: Rendering unsanitized HTML from API
+<div dangerouslySetInnerHTML={{ __html: bill.summary }} />
+
+// BAD: Leaking error details to users
+catch (error) { return <p>{error.message}: {error.stack}</p> }
+
+// BAD: External script without SRI
+<script src="https://cdn.example.com/analytics.js" />
+```
+
+---
+
 ## Changelog
 
 | Date | PRD Version | Summary |
 |------|-------------|---------|
 | 2026-02-28 | 1.0 | Initial domain rules enforcement skill |
+| 2026-03-07 | 1.1 | Add DR-008 FrontendSecurityFirstInvariant |

--- a/.claude/skills/project-guardian/SKILL.md
+++ b/.claude/skills/project-guardian/SKILL.md
@@ -7,7 +7,7 @@ description: Guardian skill that enforces PRD compliance during development. Use
 
 ## Purpose
 
-This skill ensures all development work aligns with the PRD (v1.0) for **Political Authority Highlighter**. It prevents scope creep, enforces domain rules, and maintains architectural integrity.
+This skill ensures all development work aligns with the PRD (v1.1) for **Political Authority Highlighter**. It prevents scope creep, enforces domain rules, and maintains architectural integrity.
 
 ## When to Trigger
 
@@ -22,6 +22,7 @@ This skill ensures all development work aligns with the PRD (v1.0) for **Politic
 ### 1. Is this feature in the MVP scope?
 
 Valid MVP features (RF-001 through RF-017):
+
 - RF-001: Politician Catalog Listing (cards with photo, party, tenure, score)
 - RF-002: Filter by Political Role (deputado, senador, etc.)
 - RF-003: Filter by State (UF)
@@ -41,6 +42,7 @@ Valid MVP features (RF-001 through RF-017):
 - RF-017: SEO and Social Sharing Metadata
 
 **REJECT** if the feature is in the out-of-scope list:
+
 - Comparison between politicians
 - Alerts and notifications
 - Public API for third parties
@@ -67,6 +69,7 @@ For every code change, verify against ALL domain rules:
 | DR-005: CPFNonExposureRule | Is CPF absent from API responses, frontend code, URL params, and accessible logs? |
 | DR-006: NoRetaliationDesignRule | Does this create any "worst politicians" list, lowest-score sort, or negative ranking? |
 | DR-007: IngestionIdempotencyRule | Are database writes idempotent (upserts)? Are transactions used? |
+| DR-008: FrontendSecurityFirstInvariant | Does this change introduce any data exposure, injection, or trust boundary violation in the frontend? |
 
 ### 3. Critical Constraints
 
@@ -82,6 +85,7 @@ For every code change, verify against ALL domain rules:
 ### 4. Endpoint Security Check
 
 For any new API endpoint:
+
 - [ ] Does it only query the `public_data` schema?
 - [ ] Does it use the `api_reader` database role?
 - [ ] Does it have a TypeBox response schema (no field leakage)?
@@ -92,6 +96,7 @@ For any new API endpoint:
 ### 5. UI Neutrality Check
 
 For any UI change:
+
 - [ ] Uses neutral color palette (no party colors)?
 - [ ] Presents data factually without qualitative judgment?
 - [ ] Default sort is by highest score (never by lowest)?
@@ -102,14 +107,29 @@ For any UI change:
 ### 6. Budget Impact Assessment
 
 For infrastructure changes:
+
 - [ ] Current monthly cost: calculate
 - [ ] New monthly cost: calculate
 - [ ] Total stays under $100/month?
 - [ ] Is there a cheaper alternative?
 
+### 7. Frontend Security Check
+
+For any frontend change, verify DR-008 compliance:
+
+- [ ] Content-Security-Policy header defined in `next.config.ts`? (RNF-SEC-011)
+- [ ] No `@pah/db`, `pg`, or `drizzle-orm` imports in `apps/web/` code? (RNF-SEC-012)
+- [ ] No `NEXT_PUBLIC_` variables except `NEXT_PUBLIC_API_URL`? (RNF-SEC-012)
+- [ ] All API response text rendered via JSX auto-escaping (no innerHTML)? (RNF-SEC-013)
+- [ ] `dangerouslySetInnerHTML` only in JSON-LD `<script>` tags with `JSON.stringify()`? (RNF-SEC-013)
+- [ ] Error boundaries show generic user messages only (no stack traces, no table names)? (RNF-SEC-014)
+- [ ] No external scripts without `integrity` and `crossorigin` attributes? (RNF-SEC-016)
+- [ ] `import 'server-only'` present in all `packages/db/src/` files? (RNF-SEC-012)
+
 ## Violation Response
 
 If any check fails:
+
 1. STOP implementation
 2. Document the violation
 3. Propose a compliant alternative
@@ -120,3 +140,4 @@ If any check fails:
 | Date | PRD Version | Summary |
 |------|-------------|---------|
 | 2026-02-28 | 1.0 | Initial guardian skill |
+| 2026-03-07 | 1.1 | Add Frontend Security Check (section 7) for DR-008 enforcement |

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -1,6 +1,8 @@
 # Frontend Development Guide -- Political Authority Highlighter
+
 # Stack: Next.js 15 (App Router) | React 19 | Tailwind CSS 4 | shadcn/ui
-# Last Updated: 2026-02-28 | PRD Version: 1.0
+
+# Last Updated: 2026-03-07 | PRD Version: 1.1
 
 ## Core Principles
 
@@ -21,7 +23,8 @@
 
 ## Architecture Boundaries
 
-### What the Frontend IS responsible for:
+### What the Frontend IS responsible for
+
 - Rendering politician profiles, scores, rankings, and parliamentary activity
 - SEO: metadata, Open Graph tags, JSON-LD structured data
 - Search and filter UI with URL-based state
@@ -30,14 +33,16 @@
 - Accessibility compliance (WCAG 2.1 AA)
 - Performance optimization (Core Web Vitals)
 
-### What the Frontend is NOT responsible for:
+### What the Frontend is NOT responsible for
+
 - Data fetching from government sources (that is the pipeline)
 - Score calculation or business logic (pre-computed by pipeline)
 - Database access (the frontend calls the REST API)
 - User authentication (no auth in MVP)
 - Data mutation (all data is read-only from the API)
 
-### Dependencies:
+### Dependencies
+
 - **Depends on**: Backend API (`/api/v1/*`), `packages/shared` (types, constants, utilities)
 - **Must NOT depend on**: `packages/db`, `apps/api`, `apps/pipeline`
 
@@ -210,6 +215,7 @@ async function fetchSourcesStatus(): Promise<SourceStatusResponse[]>
 ### Server Components vs Client Components
 
 **Rule**: Start with Server Components. Only add `'use client'` when the component needs:
+
 - `useState`, `useReducer`, `useEffect`, `useRef`
 - Event handlers (`onClick`, `onChange`, `onSubmit`)
 - Browser APIs (`window`, `document`, `localStorage`)
@@ -483,6 +489,7 @@ export async function fetchPoliticianBySlug(
 ```
 
 **Hard rules for color usage:**
+
 - NO red/green for "bad"/"good" politicians. Use the neutral blue scale for score visualization.
 - Score visualization uses a single-hue gradient (light blue to dark blue) or a neutral gray scale.
 - Party names displayed as text in neutral badges. Never in party-branded colors.
@@ -897,6 +904,12 @@ describe('ScoreBadge', () => {
 | Display exclusion record details (source, date, description) | Violates silent exclusion (DR-001). Only show the neutral notice text |
 | Use color to convey meaning without text alternative | WCAG 2.1 AA violation. Always pair color with text labels |
 | Skip `loading.tsx` skeleton for data-fetching pages | Causes poor UX and CLS. Every page with async data needs a skeleton |
+| Store auth tokens in localStorage/sessionStorage | Violates RNF-SEC-015. Use httpOnly Secure SameSite=Strict cookies when auth is implemented |
+| Add external `<script>` tags without SRI | Violates RNF-SEC-016. All external scripts must have `integrity` and `crossorigin` attributes |
+| Render unsanitized HTML from API with innerHTML | Violates RNF-SEC-013/DR-008. Government text rendered via JSX auto-escaping only |
+| Import `@pah/db`, `pg`, or `drizzle-orm` in frontend | Violates RNF-SEC-012/DR-008. Frontend accesses data through the API only |
+| Use `NEXT_PUBLIC_` prefix for secrets/tokens | Violates RNF-SEC-012. Only `NEXT_PUBLIC_API_URL` is permitted |
+| Expose server error details in UI | Violates RNF-SEC-014. Error boundaries show generic messages; use `digest` for correlation |
 
 ---
 
@@ -941,14 +954,46 @@ describe('ScoreBadge', () => {
 Configured via `next.config.ts` headers:
 
 ```typescript
-// next.config.ts
+// next.config.ts -- Security Headers (DR-008, RNF-SEC-011)
+const cspHeader = `
+  default-src 'self';
+  script-src 'self' 'unsafe-inline';
+  style-src 'self' 'unsafe-inline';
+  img-src 'self' blob: data: https:;
+  font-src 'self';
+  connect-src 'self' ${process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3000'};
+  object-src 'none';
+  base-uri 'self';
+  form-action 'self';
+  frame-ancestors 'none';
+  upgrade-insecure-requests;
+`
+
 const securityHeaders = [
+  {
+    key: 'Content-Security-Policy-Report-Only',
+    value: cspHeader.replace(/\s{2,}/g, ' ').trim(),
+  },
   { key: 'X-Frame-Options', value: 'DENY' },
   { key: 'X-Content-Type-Options', value: 'nosniff' },
   { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
   { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
 ]
 ```
+
+### Client Bundle Protection (RNF-SEC-012)
+
+1. **`server-only` guard**: Every file in `packages/db/src/` imports `'server-only'`. If any Client Component transitively imports these modules, `next build` fails.
+2. **ESLint restriction**: `apps/web/.eslintrc` forbids importing `@pah/db`, `pg`, `drizzle-orm`, `pg-boss` via `no-restricted-imports` rule.
+3. **CI post-build scan**: After `next build`, `.next/static/chunks/` is scanned for forbidden patterns: `drizzle-orm`, `@pah/db`, `DATABASE_URL`, `CPF_ENCRYPTION_KEY`.
+4. **Environment variable discipline**: Only `NEXT_PUBLIC_API_URL` may use the `NEXT_PUBLIC_` prefix. All other env vars are server-only.
+
+### Error Sanitization (RNF-SEC-014)
+
+- `error.tsx` boundaries display ONLY generic user-friendly messages
+- The `digest` property on Next.js errors is used for server-side correlation
+- `api-client.ts` catches `ApiError` and surfaces only the RFC 7807 `title` field to users
+- Never render: stack traces, database table names, SQL queries, internal URLs, or raw error messages from the API
 
 ---
 
@@ -957,3 +1002,4 @@ const securityHeaders = [
 | Date | PRD Version | Summary |
 |------|-------------|---------|
 | 2026-02-28 | 1.0 | Initial frontend development guide |
+| 2026-03-07 | 1.1 | Add Frontend Security First principle (DR-008), full CSP header, client bundle protection, error sanitization, SRI policy |

--- a/docs/prd/PRD.md
+++ b/docs/prd/PRD.md
@@ -1,6 +1,6 @@
 # Product Requirements Document — Political Authority Highlighter
 
-> **Version:** 1.0 | **Status:** Active | **Last Updated:** 2026-02-28
+> **Version:** 1.1 | **Status:** Active | **Last Updated:** 2026-03-07
 > **Stack reference:** [ARCHITECTURE.md](./ARCHITECTURE.md)
 > **ER model:** [ER.md](./ER.md)
 
@@ -162,6 +162,13 @@
 | RNF-SEC-008 | Security headers | Helmet.js: CSP, X-Frame-Options, X-Content-Type-Options |
 | RNF-SEC-009 | CORS restriction | Restricted to `autoridade-politica.com.br` and `localhost` |
 | RNF-SEC-010 | Dependency auditing | `npm audit` in CI, Dependabot enabled |
+| RNF-SEC-011 | Content-Security-Policy on frontend | Static CSP via `next.config.ts` `headers()`: `default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' blob: data: https:; font-src 'self'; connect-src 'self' {NEXT_PUBLIC_API_URL}; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests`. Deploy with `Content-Security-Policy-Report-Only` first, enforce after validation. Nonces NOT used (incompatible with ISR per ADR-002). |
+| RNF-SEC-012 | Client bundle sensitive data prevention | `import 'server-only'` in all `packages/db/src/` files. ESLint `no-restricted-imports` forbidding `@pah/db`, `pg`, `drizzle-orm` in `apps/web/`. CI post-build grep on `.next/static/chunks/` for forbidden patterns (`drizzle-orm`, `DATABASE_URL`, `CPF_ENCRYPTION_KEY`). Only `NEXT_PUBLIC_API_URL` may use `NEXT_PUBLIC_` prefix. |
+| RNF-SEC-013 | API response rendering safety | All government-sourced text fields rendered via React JSX auto-escaping only. No `innerHTML` or `dangerouslySetInnerHTML` except JSON-LD `<script>` tags with `JSON.stringify()` sanitized data. Pipeline transformers strip HTML tags from government source text before storing in `public_data`. |
+| RNF-SEC-014 | Error message sanitization | No server stack traces, database table names, internal URLs, or SQL query text in any user-facing error response. API returns RFC 7807 ProblemDetail with generic messages. Frontend `error.tsx` boundary shows user-friendly message only. Error `digest` property used for server-side correlation without exposing internals. |
+| RNF-SEC-015 | Future authentication token security | When authentication is implemented post-MVP: tokens stored in httpOnly Secure SameSite=Strict cookies only (never localStorage/sessionStorage). CSRF protection via double-submit cookie or Synchronizer Token pattern. JWT signed with RS256 minimum. Token rotation on privilege escalation. Session expiry <= 24 hours with sliding window. |
+| RNF-SEC-016 | Subresource Integrity for external scripts | Any external script added to the frontend must include `integrity` and `crossorigin` attributes. No external scripts permitted without SRI hashes. MVP has zero external scripts (no analytics, no third-party widgets). |
+| RNF-SEC-017 | Security testing in CI | `pnpm audit --audit-level=high` must pass. Post-build client bundle scan for forbidden patterns (server-only modules, secret variable names). Secret pattern regex scan on all staged files pre-commit. |
 
 ### 3.3 Availability & Reliability
 
@@ -249,6 +256,7 @@ The platform does not determine electoral eligibility. The anti-corruption exclu
 | DR-005 | CPFNonExposureRule | CPF numbers MUST never appear in any public-facing interface, API response, log file, error message, or URL. CPFs exist only in `internal_data.politician_identifiers` as encrypted bytes and SHA-256 hashes. | CPF stored as AES-256-GCM encrypted `bytea` and SHA-256 hash in `internal_data` schema only. Pipeline code handles CPF in memory only during ingestion. Structured logging configured to redact any 11-digit numeric patterns. |
 | DR-006 | NoRetaliationDesignRule | The platform MUST highlight positive integrity indicators. It MUST NOT expose negative details that could enable targeted retaliation against specific politicians. A low score is permissible; exposing the specific reasons from anti-corruption databases is not. | Silent exclusion pattern (ADR-004): anti-corruption component is 0 or 25, with no details. UI displays only "Information from anti-corruption databases affected this score." No drill-down into exclusion records. |
 | DR-007 | IngestionIdempotencyRule | Running the same ingestion job multiple times with the same source data MUST produce identical database state. No duplicate records, no score drift, no side effects. | Upsert operations keyed on `(source, external_id)`. Idempotency keys on `exclusion_records`. Score calculation is a pure function of current data state. `raw_source_data` deduplication via source + external_id. |
+| DR-008 | FrontendSecurityFirstInvariant | The frontend layer must never be a vector for data exposure, injection, or trust boundary violation. All frontend code changes must satisfy: (1) no server-only modules in client bundles, (2) no sensitive data in `NEXT_PUBLIC_` variables, (3) CSP headers enforced at the edge, (4) government-sourced text rendered via JSX auto-escaping only, (5) error boundaries show generic user messages only, (6) no external scripts without SRI. | Build-time: `server-only` import guard + ESLint import boundaries. CI: client bundle forbidden-pattern scan + `pnpm audit`. Runtime: CSP headers via `next.config.ts`. Code review: project-guardian checklist. |
 
 ### 4.2 Ubiquitous Language (Glossary)
 
@@ -273,12 +281,12 @@ The platform does not determine electoral eligibility. The anti-corruption exclu
 
 | System | Type | Protocol | Auth Method | Rate Limit | Cadence | Official Docs |
 |--------|------|----------|-------------|------------|---------|---------------|
-| Camara dos Deputados API | REST API | HTTPS, JSON | None (public) | No published limit | Daily | https://dadosabertos.camara.leg.br/swagger/api.html |
-| Senado Federal API | REST API | HTTPS, XML/JSON | None (public) | No published limit | Daily | https://legis.senado.leg.br/dadosabertos/ |
-| Portal da Transparencia | REST API | HTTPS, JSON | API key (header) | 90 req/min | Daily | https://portaldatransparencia.gov.br/api-de-dados |
-| TSE (Tribunal Superior Eleitoral) | Bulk Data | HTTPS, CSV download | None (public) | N/A (bulk) | Weekly | https://dadosabertos.tse.jus.br/ |
-| TCU CADIRREG | REST API | HTTPS, JSON | None (public) | No published limit | Weekly | https://portal.tcu.gov.br/contas/contas-e-relatorios/ |
-| CGU-PAD | Bulk Data | HTTPS, CSV download | None (public) | N/A (bulk) | Monthly | https://www.gov.br/cgu/pt-br/acesso-a-informacao/dados-abertos |
+| Camara dos Deputados API | REST API | HTTPS, JSON | None (public) | No published limit | Daily | <https://dadosabertos.camara.leg.br/swagger/api.html> |
+| Senado Federal API | REST API | HTTPS, XML/JSON | None (public) | No published limit | Daily | <https://legis.senado.leg.br/dadosabertos/> |
+| Portal da Transparencia | REST API | HTTPS, JSON | API key (header) | 90 req/min | Daily | <https://portaldatransparencia.gov.br/api-de-dados> |
+| TSE (Tribunal Superior Eleitoral) | Bulk Data | HTTPS, CSV download | None (public) | N/A (bulk) | Weekly | <https://dadosabertos.tse.jus.br/> |
+| TCU CADIRREG | REST API | HTTPS, JSON | None (public) | No published limit | Weekly | <https://portal.tcu.gov.br/contas/contas-e-relatorios/> |
+| CGU-PAD | Bulk Data | HTTPS, CSV download | None (public) | N/A (bulk) | Monthly | <https://www.gov.br/cgu/pt-br/acesso-a-informacao/dados-abertos> |
 
 ### Integration Details
 
@@ -322,16 +330,16 @@ The platform does not determine electoral eligibility. The anti-corruption exclu
 
 | Topic | Source | URL | Validated |
 |-------|--------|-----|-----------|
-| Camara dos Deputados Open Data | Brazilian Chamber of Deputies | https://dadosabertos.camara.leg.br/ | Yes |
-| Senado Federal Open Data | Brazilian Federal Senate | https://legis.senado.leg.br/dadosabertos/ | Yes |
-| Portal da Transparencia API | Brazilian Comptroller General (CGU) | https://portaldatransparencia.gov.br/api-de-dados | Yes |
-| TSE Open Data | Brazilian Superior Electoral Court | https://dadosabertos.tse.jus.br/ | Yes |
-| TCU Open Data | Brazilian Federal Court of Accounts | https://portal.tcu.gov.br/ | Yes |
-| CGU Open Data | Brazilian Comptroller General | https://www.gov.br/cgu/pt-br/acesso-a-informacao/dados-abertos | Yes |
-| LGPD Full Text | Brazilian Government | https://www.planalto.gov.br/ccivil_03/_ato2015-2018/2018/lei/l13709.htm | Yes |
-| LAI Full Text | Brazilian Government | https://www.planalto.gov.br/ccivil_03/_ato2011-2014/2011/lei/l12527.htm | Yes |
-| Lei da Ficha Limpa | Brazilian Government | https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp135.htm | Yes |
-| Marco Civil da Internet | Brazilian Government | https://www.planalto.gov.br/ccivil_03/_ato2011-2014/2014/lei/l12965.htm | Yes |
+| Camara dos Deputados Open Data | Brazilian Chamber of Deputies | <https://dadosabertos.camara.leg.br/> | Yes |
+| Senado Federal Open Data | Brazilian Federal Senate | <https://legis.senado.leg.br/dadosabertos/> | Yes |
+| Portal da Transparencia API | Brazilian Comptroller General (CGU) | <https://portaldatransparencia.gov.br/api-de-dados> | Yes |
+| TSE Open Data | Brazilian Superior Electoral Court | <https://dadosabertos.tse.jus.br/> | Yes |
+| TCU Open Data | Brazilian Federal Court of Accounts | <https://portal.tcu.gov.br/> | Yes |
+| CGU Open Data | Brazilian Comptroller General | <https://www.gov.br/cgu/pt-br/acesso-a-informacao/dados-abertos> | Yes |
+| LGPD Full Text | Brazilian Government | <https://www.planalto.gov.br/ccivil_03/_ato2015-2018/2018/lei/l13709.htm> | Yes |
+| LAI Full Text | Brazilian Government | <https://www.planalto.gov.br/ccivil_03/_ato2011-2014/2011/lei/l12527.htm> | Yes |
+| Lei da Ficha Limpa | Brazilian Government | <https://www.planalto.gov.br/ccivil_03/leis/lcp/lcp135.htm> | Yes |
+| Marco Civil da Internet | Brazilian Government | <https://www.planalto.gov.br/ccivil_03/_ato2011-2014/2014/lei/l12965.htm> | Yes |
 
 ---
 
@@ -340,3 +348,4 @@ The platform does not determine electoral eligibility. The anti-corruption exclu
 | Version | Date | Change | Updated Artifacts |
 |---------|------|--------|-------------------|
 | 1.0 | 2026-02-28 | Initial PRD — 17 functional requirements, 6 data sources, domain model, compliance framework | PRD.md, ARCHITECTURE.md, ER.md |
+| 1.1 | 2026-03-07 | Frontend security-first principle — 7 new security NFRs (RNF-SEC-011 to RNF-SEC-017), new domain rule DR-008 (FrontendSecurityFirstInvariant) | PRD.md, project-guardian, project-domain-rules, project-compliance, project-cicd, apps/web/CLAUDE.md |

--- a/docs/stack/nextjs-15-csp.md
+++ b/docs/stack/nextjs-15-csp.md
@@ -1,0 +1,284 @@
+# Next.js 15 Content-Security-Policy with App Router on Vercel
+
+> Researched: 2026-03-07
+> Sources: nextjs.org/docs (v16.1.6 page, last updated 2026-02-27), vercel.com/docs, tailwindcss.com/docs
+> Applicability: Next.js 15 App Router, Vercel Free tier, ISR, Tailwind CSS, no external scripts
+
+---
+
+## TL;DR for Political Authority Highlighter
+
+**Use the static CSP approach (no nonces) via `next.config.ts` `headers()`.** Nonces are incompatible with ISR because they require dynamic rendering on every request. Since this project has no external scripts, no user input forms, and uses Tailwind CSS (which compiles to static CSS files), a static CSP with `'unsafe-inline'` for `style-src` and `'self'` for `script-src` provides strong protection without sacrificing ISR performance.
+
+For JSON-LD inline scripts, use `'unsafe-inline'` in `script-src` (acceptable for a read-only app with no user-generated content) or migrate to the experimental SRI feature when it stabilizes.
+
+---
+
+## Key Finding 1: Nonces Are Incompatible with ISR
+
+From the official Next.js CSP guide (nextjs.org/docs/app/guides/content-security-policy):
+
+> "When you use nonces in your CSP, **all pages must be dynamically rendered**."
+
+Specific consequences of nonce-based CSP:
+
+- **ISR is disabled** -- pages cannot use `revalidate` with nonces
+- **No CDN caching** -- dynamic pages set `Cache-Control: private, no-cache, no-store`
+- **PPR (Partial Prerendering) is incompatible** with nonce-based CSP
+- **Every request triggers SSR** -- increased server load and latency
+- **Higher hosting costs** -- more compute per request
+
+**Why:** Nonces must be unique per request. ISR serves cached HTML across multiple requests. A cached nonce would be reused, defeating its security purpose.
+
+### Nonce Implementation (for reference, NOT recommended for this project)
+
+If nonces were needed, the approach uses `proxy.ts` (formerly `middleware.ts`):
+
+```ts
+// proxy.ts -- generates per-request nonce
+import { NextRequest, NextResponse } from 'next/server'
+
+export function proxy(request: NextRequest) {
+  const nonce = Buffer.from(crypto.randomUUID()).toString('base64')
+  const cspHeader = `
+    default-src 'self';
+    script-src 'self' 'nonce-${nonce}' 'strict-dynamic';
+    style-src 'self' 'nonce-${nonce}';
+    ...
+  `
+  // Sets x-nonce header for Server Components to read
+  const requestHeaders = new Headers(request.headers)
+  requestHeaders.set('x-nonce', nonce)
+  requestHeaders.set('Content-Security-Policy', cspHeader)
+  // ...
+}
+```
+
+Pages would need `await connection()` to force dynamic rendering.
+
+---
+
+## Key Finding 2: Recommended Approach -- Static CSP via `next.config.ts`
+
+For apps that use ISR (like this project), Next.js recommends setting CSP headers directly in `next.config.ts` using `headers()`:
+
+```ts
+// next.config.ts
+const isDev = process.env.NODE_ENV === 'development'
+
+const cspHeader = `
+  default-src 'self';
+  script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ''};
+  style-src 'self' 'unsafe-inline';
+  img-src 'self' blob: data:;
+  font-src 'self';
+  object-src 'none';
+  base-uri 'self';
+  form-action 'self';
+  frame-ancestors 'none';
+  upgrade-insecure-requests;
+`
+
+export default {
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: [
+          {
+            key: 'Content-Security-Policy',
+            value: cspHeader.replace(/\n/g, ''),
+          },
+        ],
+      },
+    ]
+  },
+}
+```
+
+### Why `'unsafe-inline'` is acceptable here
+
+- **No user-generated content** -- the app is read-only public data
+- **No external scripts** -- no Google Analytics, no third-party widgets
+- **No authentication** -- no session tokens to steal via XSS
+- **JSON-LD scripts** are inline `<script type="application/ld+json">` tags rendered by Server Components; nonces cannot be applied to them with ISR, so `'unsafe-inline'` in `script-src` is needed
+- **Tailwind CSS** compiles to static `.css` files with class selectors; it does NOT inject inline `style` attributes at runtime, so `'unsafe-inline'` for `style-src` is a belt-and-suspenders approach (some Next.js internal styles may need it)
+
+---
+
+## Key Finding 3: Experimental SRI (Subresource Integrity) -- Future Option
+
+Next.js has an experimental feature that enables hash-based CSP with static generation:
+
+```ts
+// next.config.ts
+export default {
+  experimental: {
+    sri: {
+      algorithm: 'sha256', // or 'sha384' or 'sha512'
+    },
+  },
+}
+```
+
+**Benefits:**
+
+- Maintains static generation and ISR compatibility
+- Adds `integrity` attributes to `<script>` tags at build time
+- Browsers verify scripts haven't been tampered with
+- Can use strict `script-src 'self'` without `'unsafe-inline'`
+
+**Limitations (as of 2026-03-07):**
+
+- **Experimental** -- may change or be removed
+- **Webpack only** -- NOT available with Turbopack
+- **App Router only** -- not supported in Pages Router
+- **Build-time only** -- cannot handle dynamically generated scripts (like JSON-LD with dynamic data)
+- Does NOT solve inline `<script type="application/ld+json">` -- those still need `'unsafe-inline'` or a nonce
+
+**Recommendation:** Monitor this feature. When it stabilizes and supports Turbopack, it could replace `'unsafe-inline'` in `script-src` for framework scripts. JSON-LD would still need a separate solution.
+
+---
+
+## Key Finding 4: Tailwind CSS and CSP
+
+From tailwindcss.com/docs/preflight and the Tailwind architecture:
+
+- Tailwind CSS generates **static CSS files** with utility classes
+- It does **NOT inject inline `style` attributes** at runtime
+- All styles are delivered through compiled `.css` files using CSS layers
+- CSS custom properties (variables) are declared in the stylesheet, not inline
+
+**Conclusion:** Tailwind CSS is fully compatible with strict CSP. The `'unsafe-inline'` in `style-src` is NOT required for Tailwind itself. However, some Next.js internals or shadcn/ui components may use inline styles, so `'unsafe-inline'` in `style-src` provides a safety margin.
+
+If you want to test without `'unsafe-inline'` in `style-src`, set CSP to `style-src 'self'` and monitor the browser console for violations. If none appear, you can drop `'unsafe-inline'`.
+
+---
+
+## Key Finding 5: Vercel Platform Considerations
+
+From vercel.com/docs/headers/security-headers:
+
+- Vercel recommends nonces for inline scripts/styles (but this conflicts with ISR)
+- Vercel recommends starting with `Content-Security-Policy-Report-Only` before enforcing
+- Vercel recommends avoiding `unsafe-inline` and `unsafe-eval` as a best practice
+- The Vercel Toolbar (dev tool) has known issues with strict CSP -- not a concern for production
+- CSP headers set via `next.config.ts` `headers()` are properly served by Vercel's CDN
+- ISR-cached pages will include the static CSP header on every response
+
+---
+
+## Concrete CSP Policy for Political Authority Highlighter
+
+### Production policy (recommended for MVP)
+
+```
+default-src 'self';
+script-src 'self' 'unsafe-inline';
+style-src 'self' 'unsafe-inline';
+img-src 'self' blob: data:;
+font-src 'self';
+connect-src 'self' https://<FASTIFY_API_DOMAIN>;
+object-src 'none';
+base-uri 'self';
+form-action 'self';
+frame-ancestors 'none';
+upgrade-insecure-requests;
+```
+
+### Directive explanations
+
+| Directive | Value | Reason |
+|-----------|-------|--------|
+| `default-src` | `'self'` | Only allow resources from same origin |
+| `script-src` | `'self' 'unsafe-inline'` | Allow own scripts + JSON-LD inline scripts |
+| `style-src` | `'self' 'unsafe-inline'` | Allow own stylesheets + any Next.js/shadcn inline styles |
+| `img-src` | `'self' blob: data:` | Allow own images + Next.js Image optimization (blob/data URIs) |
+| `font-src` | `'self'` | Allow self-hosted fonts only |
+| `connect-src` | `'self' https://<API>` | Allow API calls to the Fastify backend |
+| `object-src` | `'none'` | Block plugins (Flash, Java, etc.) |
+| `base-uri` | `'self'` | Prevent base tag hijacking |
+| `form-action` | `'self'` | No forms in MVP, but restrict as defense-in-depth |
+| `frame-ancestors` | `'none'` | Prevent clickjacking (equivalent to X-Frame-Options: DENY) |
+| `upgrade-insecure-requests` | (present) | Force HTTPS for all subresources |
+
+### Development policy additions
+
+Add `'unsafe-eval'` to `script-src` in development only (React debugging requires `eval()`).
+
+### Implementation in next.config.ts
+
+```ts
+import type { NextConfig } from 'next'
+
+const isDev = process.env.NODE_ENV === 'development'
+const apiUrl = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001'
+
+const cspHeader = `
+  default-src 'self';
+  script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ''};
+  style-src 'self' 'unsafe-inline';
+  img-src 'self' blob: data:;
+  font-src 'self';
+  connect-src 'self' ${apiUrl};
+  object-src 'none';
+  base-uri 'self';
+  form-action 'self';
+  frame-ancestors 'none';
+  ${isDev ? '' : 'upgrade-insecure-requests;'}
+`
+
+const nextConfig: NextConfig = {
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: [
+          {
+            key: 'Content-Security-Policy',
+            value: cspHeader.replace(/\s{2,}/g, ' ').trim(),
+          },
+          {
+            key: 'X-Content-Type-Options',
+            value: 'nosniff',
+          },
+          {
+            key: 'Referrer-Policy',
+            value: 'strict-origin-when-cross-origin',
+          },
+          {
+            key: 'X-Frame-Options',
+            value: 'DENY',
+          },
+          {
+            key: 'Permissions-Policy',
+            value: 'camera=(), microphone=(), geolocation=()',
+          },
+        ],
+      },
+    ]
+  },
+}
+
+export default nextConfig
+```
+
+> Note: `upgrade-insecure-requests` is excluded in dev to avoid issues with `http://localhost`.
+
+---
+
+## Rollout Strategy
+
+1. **Phase 1:** Deploy with `Content-Security-Policy-Report-Only` header to detect violations without breaking the site
+2. **Phase 2:** Monitor browser console and/or set up a `report-uri` endpoint to collect violations
+3. **Phase 3:** Switch to enforcing `Content-Security-Policy` once no legitimate violations are detected
+4. **Phase 4 (future):** When experimental SRI stabilizes, evaluate removing `'unsafe-inline'` from `script-src`
+
+---
+
+## Sources
+
+- [Next.js CSP Guide (App Router)](https://nextjs.org/docs/app/guides/content-security-policy) -- official, last updated 2026-02-27
+- [Vercel Security Headers](https://vercel.com/docs/headers/security-headers) -- official Vercel documentation
+- [Tailwind CSS Preflight](https://tailwindcss.com/docs/preflight) -- confirms no inline style injection
+- [MDN Content-Security-Policy](https://developer.mozilla.org/docs/Web/HTTP/CSP) -- reference standard

--- a/docs/stack/nextjs-client-bundle-security.md
+++ b/docs/stack/nextjs-client-bundle-security.md
@@ -1,0 +1,457 @@
+# Next.js Client Bundle Analysis & Sensitive Data Leak Prevention
+
+> Researched: 2026-03-07 | Next.js version: 15+ (verified against v16.1.6 docs) | Status: complete
+
+## 1. The `server-only` Package
+
+### What It Does
+
+The `server-only` package causes a **build-time error** if a module that imports it is
+transitively imported into a Client Component (any file in the `'use client'` module graph).
+This is the primary defense against server code leaking into the client bundle.
+
+### How Next.js Handles It
+
+From the official docs: _"Next.js handles `server-only` and `client-only` imports internally
+to provide clearer error messages when a module is used in the wrong environment. The contents
+of these packages from NPM are not used by Next.js."_
+
+Installing the npm package is **optional** -- Next.js recognizes `import 'server-only'`
+natively. However, installing it avoids linting warnings about extraneous dependencies.
+
+Next.js also provides its own type declarations for `server-only` and `client-only`, for
+TypeScript configurations where `noUncheckedSideEffectImports` is active.
+
+### Installation
+
+```bash
+pnpm add server-only
+# Optionally also:
+pnpm add client-only
+```
+
+### Usage Pattern
+
+Add `import 'server-only'` at the top of any module that must never reach the client:
+
+```typescript
+// packages/db/src/public-schema.ts
+import 'server-only'
+
+// ... Drizzle schema definitions
+```
+
+```typescript
+// apps/web/src/lib/api-client.ts (server-side fetch wrapper)
+import 'server-only'
+
+export async function fetchPoliticianBySlug(slug: string) {
+  // Uses process.env.NEXT_PUBLIC_API_URL but also accesses
+  // server-only caching features
+}
+```
+
+### Where to Apply in This Project
+
+| File / Package | Reason |
+|----------------|--------|
+| `packages/db/src/public-schema.ts` | Drizzle schema must never appear in client bundle |
+| `packages/db/src/internal-schema.ts` | Internal schema -- doubly critical |
+| `packages/db/src/clients.ts` | Database connection strings |
+| `apps/web/src/app/api/revalidate/route.ts` | Uses `VERCEL_REVALIDATE_TOKEN` |
+| Any future DAL (Data Access Layer) files | Per Next.js security guide recommendation |
+
+**Source:** [Server and Client Components -- nextjs.org](https://nextjs.org/docs/app/getting-started/server-and-client-components)
+
+---
+
+## 2. `serverExternalPackages` in next.config.ts
+
+### What It Does
+
+Packages imported inside Server Components and Route Handlers are **automatically bundled**
+by Next.js. The `serverExternalPackages` option opts specific packages out of this bundling,
+making them use native Node.js `require` instead. This is for packages with Node.js-specific
+features (native bindings, `fs`, `net`, etc.).
+
+### Important Distinction
+
+`serverExternalPackages` controls **server-side** bundling behavior -- it does NOT prevent
+packages from appearing in client bundles. That is the job of `server-only`.
+
+However, it is still relevant because some packages (like `pg`, database drivers) could
+cause build failures if the bundler tries to resolve their Node.js dependencies. Next.js
+already auto-excludes `pg` from bundling by default.
+
+### Pre-configured Packages (auto-excluded)
+
+Next.js maintains a built-in list. Relevant entries for this project:
+
+- `pg` (PostgreSQL driver -- already excluded)
+- `better-sqlite3`, `mongodb`, `mongoose`, `@prisma/client` (not used but illustrative)
+- `sharp` (image processing)
+- `pino` (logger -- used by Fastify)
+
+### Configuration for This Project
+
+```typescript
+// apps/web/next.config.ts
+import type { NextConfig } from 'next'
+
+const config: NextConfig = {
+  serverExternalPackages: [
+    // drizzle-orm uses pg under the hood
+    'drizzle-orm',
+    '@pah/db',
+  ],
+  // ... existing config
+}
+```
+
+**Note:** Since `apps/web` should never import `@pah/db` at all (per import boundaries),
+this is a **defense-in-depth** measure. The primary protection is the `server-only` import
+in `packages/db/`.
+
+**Source:** [serverExternalPackages -- nextjs.org](https://nextjs.org/docs/app/api-reference/config/next-config-js/serverExternalPackages)
+
+---
+
+## 3. Bundle Analysis Tools
+
+### Option A: Next.js Bundle Analyzer for Turbopack (v16.1+, experimental)
+
+```bash
+pnpm next experimental-analyze
+# Or to write output to disk (for CI diffing):
+pnpm next experimental-analyze --output
+```
+
+Features:
+
+- Filter by route, environment (client vs server), and type (JS, CSS, JSON)
+- View full import chain for any module
+- Trace imports across server-to-client boundaries
+- Output written to `.next/diagnostics/analyze` with `--output` flag
+
+### Option B: `@next/bundle-analyzer` (Webpack, stable)
+
+```bash
+pnpm add -D @next/bundle-analyzer
+```
+
+```typescript
+// apps/web/next.config.ts
+import type { NextConfig } from 'next'
+import withBundleAnalyzer from '@next/bundle-analyzer'
+
+const config: NextConfig = {
+  // ... existing config
+}
+
+export default process.env.ANALYZE === 'true'
+  ? withBundleAnalyzer({ enabled: true })(config)
+  : config
+```
+
+```bash
+ANALYZE=true pnpm --filter @pah/web build
+```
+
+Opens 3 HTML reports in browser showing client, server, and edge bundles with treemap
+visualization.
+
+### Can They Detect Server Module Leaks?
+
+**Partially.** The bundle analyzer shows what modules are in each bundle, so you can
+visually inspect the client bundle for unexpected server dependencies (e.g., `drizzle-orm`,
+`pg`, `@pah/db`). However, this is a **manual** inspection. For automated CI checks, see
+Section 4 below.
+
+**Source:** [Package Bundling Guide -- nextjs.org](https://nextjs.org/docs/app/guides/package-bundling)
+
+---
+
+## 4. CI Step: Verify No Server-Only Code in Client Chunks
+
+Next.js does not provide a built-in CLI command for this. However, since `next build` outputs
+client chunks to `.next/static/chunks/`, you can grep them for forbidden module identifiers.
+
+### Approach: Post-Build Grep Script
+
+```bash
+#!/usr/bin/env bash
+# scripts/check-client-bundle.sh
+# Fails CI if forbidden server-only modules appear in client JavaScript chunks.
+
+set -euo pipefail
+
+FORBIDDEN_PATTERNS=(
+  "drizzle-orm"
+  "@pah/db"
+  "public-schema"
+  "internal-schema"
+  "pg-boss"
+  "CPF_ENCRYPTION_KEY"
+  "DATABASE_URL"
+  "VERCEL_REVALIDATE_TOKEN"
+)
+
+CLIENT_CHUNKS_DIR="apps/web/.next/static/chunks"
+
+if [ ! -d "$CLIENT_CHUNKS_DIR" ]; then
+  echo "ERROR: Client chunks directory not found. Run 'next build' first."
+  exit 1
+fi
+
+FOUND=0
+for pattern in "${FORBIDDEN_PATTERNS[@]}"; do
+  if grep -rl "$pattern" "$CLIENT_CHUNKS_DIR" 2>/dev/null; then
+    echo "SECURITY VIOLATION: '$pattern' found in client bundle!"
+    FOUND=1
+  fi
+done
+
+if [ "$FOUND" -eq 1 ]; then
+  echo ""
+  echo "Client bundle contains server-only code. This is a security violation."
+  echo "Check that 'import \"server-only\"' is present in all server modules."
+  exit 1
+fi
+
+echo "Client bundle check passed: no forbidden patterns found."
+```
+
+### CI Integration
+
+```yaml
+# .github/workflows/ci.yml -- add after the Build step
+- name: Check client bundle for server-only leaks
+  run: bash scripts/check-client-bundle.sh
+```
+
+### Why This Works
+
+After `next build`, all client-side JavaScript is written to `.next/static/chunks/`.
+Even minified, module names and string literals like `drizzle-orm`, `DATABASE_URL`, etc.
+are often preserved (especially package names in import paths and error messages). Grepping
+for these patterns catches leaks that `server-only` might miss if someone forgets to add it.
+
+### Limitations
+
+- Minification may obscure some patterns (unlikely for package names)
+- False positives if a pattern appears in unrelated client code (e.g., a UI string)
+- Does not catch data leaks via props (use React Taint API for that)
+
+---
+
+## 5. ESLint Rules for Import Boundary Enforcement
+
+### `import/no-restricted-paths`
+
+This rule from `eslint-plugin-import` prevents files in specific directories from importing
+modules from forbidden directories. It operates on **resolved paths**, not import strings.
+
+```javascript
+// .eslintrc.cjs (or equivalent ESLint config for apps/web)
+module.exports = {
+  plugins: ['import'],
+  rules: {
+    'import/no-restricted-paths': ['error', {
+      zones: [
+        // Prevent ANY web app code from importing @pah/db
+        {
+          target: './apps/web/src',
+          from: './packages/db',
+          message: 'Frontend must not import database packages. Use the API client instead.',
+        },
+        // Prevent ANY web app code from importing api internals
+        {
+          target: './apps/web/src',
+          from: './apps/api',
+          message: 'Frontend must not import API internals.',
+        },
+        // Prevent ANY web app code from importing pipeline internals
+        {
+          target: './apps/web/src',
+          from: './apps/pipeline',
+          message: 'Frontend must not import pipeline internals.',
+        },
+      ],
+    }],
+  },
+}
+```
+
+### `no-restricted-imports` (built-in ESLint)
+
+For a simpler approach that does not require `eslint-plugin-import`:
+
+```javascript
+// ESLint config for apps/web
+rules: {
+  'no-restricted-imports': ['error', {
+    patterns: [
+      {
+        group: ['@pah/db', '@pah/db/*'],
+        message: 'Database package must never be imported in the frontend.',
+      },
+      {
+        group: ['pg', 'pg-pool', 'postgres', 'drizzle-orm/pg-core'],
+        message: 'PostgreSQL packages must never be imported in the frontend.',
+      },
+      {
+        group: ['pg-boss'],
+        message: 'pg-boss is a server-only package.',
+      },
+    ],
+  }],
+}
+```
+
+**Source:** [eslint-plugin-import no-restricted-paths](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-restricted-paths.md), [ESLint no-restricted-imports](https://eslint.org/docs/latest/rules/no-restricted-imports)
+
+---
+
+## 6. Environment Variable Security
+
+### How `NEXT_PUBLIC_` Works
+
+From official docs: _"Non-`NEXT_PUBLIC_` environment variables are only available in the
+Node.js environment, meaning they aren't accessible to the browser."_
+
+Next.js replaces `process.env.NEXT_PUBLIC_*` references with **hard-coded values at build
+time** (inlined into the JS bundle). Non-prefixed variables are replaced with empty strings
+in client code.
+
+### Key Rules for This Project
+
+| Variable | Prefix | Exposure |
+|----------|--------|----------|
+| `NEXT_PUBLIC_API_URL` | `NEXT_PUBLIC_` | Intentionally public -- API base URL |
+| `VERCEL_REVALIDATE_TOKEN` | None | Server-only -- safe |
+| `DATABASE_URL` | None | Server-only -- safe (but should never be in web env) |
+| `CPF_ENCRYPTION_KEY` | None | Server-only -- safe (pipeline only) |
+
+### Prevention Patterns
+
+1. **Never prefix secrets with `NEXT_PUBLIC_`** -- this is obvious but the most common mistake.
+
+2. **Validate at build time** -- add a check script:
+
+   ```bash
+   # scripts/check-env-prefixes.sh
+   # Ensure no secret-looking variables use NEXT_PUBLIC_ prefix
+   DANGEROUS_PREFIXES=(
+     "NEXT_PUBLIC_DATABASE"
+     "NEXT_PUBLIC_SECRET"
+     "NEXT_PUBLIC_TOKEN"
+     "NEXT_PUBLIC_KEY"
+     "NEXT_PUBLIC_PASSWORD"
+     "NEXT_PUBLIC_CPF"
+     "NEXT_PUBLIC_ENCRYPTION"
+   )
+   for prefix in "${DANGEROUS_PREFIXES[@]}"; do
+     if env | grep -q "^${prefix}"; then
+       echo "SECURITY ERROR: Environment variable with dangerous prefix found: $prefix"
+       exit 1
+     fi
+   done
+   echo "Environment variable prefix check passed."
+   ```
+
+3. **Use React Taint API** (experimental) for additional protection:
+
+   ```typescript
+   // next.config.ts
+   const config: NextConfig = {
+     experimental: {
+       taint: true,
+     },
+   }
+   ```
+
+   Then in server code:
+
+   ```typescript
+   import { experimental_taintUniqueValue } from 'react'
+
+   // Prevents this value from ever being passed to a Client Component
+   experimental_taintUniqueValue(
+     'Do not pass database connection string to client',
+     globalThis,
+     process.env.DATABASE_URL
+   )
+   ```
+
+**Source:** [Environment Variables -- nextjs.org](https://nextjs.org/docs/pages/guides/environment-variables), [Data Security Guide -- nextjs.org](https://nextjs.org/docs/app/guides/data-security)
+
+---
+
+## 7. Concrete Recommendations for This Project
+
+### Layer 1: Build-time Guards (Highest Priority)
+
+1. **Add `import 'server-only'`** to every file in `packages/db/src/`:
+   - `public-schema.ts`
+   - `internal-schema.ts`
+   - `clients.ts`
+   - `migrate.ts`
+
+   This causes an immediate build failure if any client component transitively imports
+   these modules.
+
+2. **Install `server-only`** in the `packages/db` package:
+
+   ```bash
+   pnpm --filter @pah/db add server-only
+   ```
+
+### Layer 2: Lint-time Guards
+
+1. **Add `no-restricted-imports`** to `apps/web` ESLint config to forbid:
+   - `@pah/db` and `@pah/db/*`
+   - `pg`, `drizzle-orm/pg-core`, `pg-boss`
+   - Any other server-only packages
+
+2. **Add `import/no-restricted-paths`** zones (requires `eslint-plugin-import`):
+   - `apps/web/src` cannot import from `packages/db/`
+   - `apps/web/src` cannot import from `apps/api/`
+   - `apps/web/src` cannot import from `apps/pipeline/`
+
+### Layer 3: CI Post-Build Verification
+
+1. **Add the grep script** (`scripts/check-client-bundle.sh`) as a CI step after `next build`.
+   This catches leaks that escaped layers 1 and 2.
+
+2. **Periodically run bundle analyzer** (`ANALYZE=true pnpm build` or
+   `pnpm next experimental-analyze --output`) and review client bundle composition.
+
+### Layer 4: Environment Variable Hygiene
+
+1. **Only `NEXT_PUBLIC_API_URL`** should have the `NEXT_PUBLIC_` prefix in the web app.
+   Add the env prefix check script to CI.
+
+2. **Add `VERCEL_REVALIDATE_TOKEN`** access only in `apps/web/src/app/api/revalidate/route.ts`
+   (a Route Handler, which is server-only by definition).
+
+### Layer 5: Defense in Depth (Optional)
+
+1. **`serverExternalPackages`** in `next.config.ts` for `drizzle-orm` and `@pah/db`.
+
+2. **React Taint API** (`experimental.taint: true`) for marking sensitive values that must
+    never cross the server-client boundary via props.
+
+---
+
+## Summary of All Sources
+
+| Source | URL | Domain | Official |
+|--------|-----|--------|----------|
+| Server and Client Components | <https://nextjs.org/docs/app/getting-started/server-and-client-components> | nextjs.org | Yes |
+| Data Security Guide | <https://nextjs.org/docs/app/guides/data-security> | nextjs.org | Yes |
+| serverExternalPackages | <https://nextjs.org/docs/app/api-reference/config/next-config-js/serverExternalPackages> | nextjs.org | Yes |
+| Package Bundling Guide | <https://nextjs.org/docs/app/guides/package-bundling> | nextjs.org | Yes |
+| Environment Variables | <https://nextjs.org/docs/pages/guides/environment-variables> | nextjs.org | Yes |
+| Production Checklist | <https://nextjs.org/docs/app/guides/production-checklist> | nextjs.org | Yes |
+| eslint-plugin-import no-restricted-paths | <https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-restricted-paths.md> | github.com | Yes (official repo) |
+| ESLint no-restricted-imports | <https://eslint.org/docs/latest/rules/no-restricted-imports> | eslint.org | Yes |


### PR DESCRIPTION
## Summary

Evolve PRD from v1.0 to v1.1 to establish a security-first principle for all frontend implementation. This adds 7 new security non-functional requirements (RNF-SEC-011 to RNF-SEC-017) and introduces a new domain rule (DR-008: FrontendSecurityFirstInvariant) as cross-cutting concerns that apply to all frontend development.

## Key Changes

### 1. **Security Non-Functional Requirements** (PRD §3.2)
- **RNF-SEC-011**: Content Security Policy via `next.config.ts` headers() with Report-Only initial deployment
- **RNF-SEC-012**: Client bundle protection via server-only imports and ESLint import boundary restrictions
- **RNF-SEC-013**: API response rendering via JSX auto-escaping only (never dangerouslySetInnerHTML)
- **RNF-SEC-014**: Error boundary sanitization (no stack traces, table names, or internal URLs)
- **RNF-SEC-015**: Future auth token security (httpOnly Secure SameSite=Strict cookies, CSRF protection, RS256 JWT)
- **RNF-SEC-016**: Subresource Integrity (SRI) for external scripts with integrity/crossorigin attributes
- **RNF-SEC-017**: Security testing in CI (pnpm audit --audit-level=high + client bundle leak scan)

### 2. **New Domain Rule** (PRD §4.1)
- **DR-008: FrontendSecurityFirstInvariant**: Frontend must never be a vector for data exposure, injection, or trust boundary violation
  - No database/ORM imports in web app
  - No NEXT_PUBLIC_ except API_URL
  - CSP header enforcement
  - server-only guards on all db modules
  - JSX auto-escaping for all API data

### 3. **Implementation Guides** (Project Skills)
- **project-guardian**: Added §7 Frontend Security Check with 8-point verification checklist
- **project-domain-rules**: Full DR-008 section with anti-patterns and code review checklist
- **project-compliance**: New "Frontend Security Baseline" subsection with 12-point implementation checklist
- **project-cicd**: Added pnpm audit to CI stack; added Security CI Steps section with 3 automated checks

### 4. **Frontend Development Guide** (apps/web/CLAUDE.md)
- Complete CSP header example using Content-Security-Policy-Report-Only
- Full CSP policy string with all necessary directives
- Client bundle protection implementation details
- Error sanitization patterns
- Updated "What NEVER to Do" table with 6 new security-related entries

### 5. **MVP Implementation Roadmap** (rf-mvp-remaining-features.prd.md)
- Added Phase 10: "Frontend Security Hardening (DR-008)"
- Detailed implementation tasks: CSP header, server-only guards, ESLint restrictions, CI bundle scan

### 6. **Research Documentation** (docs/stack/)
- `nextjs-15-csp.md`: CSP configuration patterns with Next.js 15 and ISR
- `nextjs-client-bundle-security.md`: Defense layers for preventing database module leakage to client bundle

## Key Decisions

✅ **CSP Deployment Mode**: Report-Only first (nonces incompatible with ISR static generation per ADR-002)  
✅ **HTML Stripping**: Applied in pipeline (RF-013) only; existing content left unchanged  
✅ **Database Access Guard**: server-only import + ESLint restrictions (compile-time enforcement)  
✅ **CI Security Checks**: pnpm audit + grep-based forbidden pattern detection in .next/static/chunks/  

## Files Changed

- docs/prd/PRD.md
- .claude/skills/project-guardian/SKILL.md
- .claude/skills/project-domain-rules/SKILL.md
- .claude/skills/project-compliance/SKILL.md
- .claude/skills/project-cicd/SKILL.md
- apps/web/CLAUDE.md
- .claude/PRPs/prds/rf-mvp-remaining-features.prd.md
- docs/stack/nextjs-15-csp.md (new)
- docs/stack/nextjs-client-bundle-security.md (new)

## Impact

- **Architecture**: No changes (existing two-schema RBAC + Drizzle already covered ~70% of security concerns)
- **Implementation**: Phase 10 of MVP roadmap (4 parallel work streams, ~3 story points)
- **Testing**: CI already validates with pnpm audit; manual CSP validation recommended
- **Breaking Changes**: None (CSP Report-Only does not block resources)

## Related Issues

Resolves part of security hardening for MVP phase completion.

---

prd-generator-plugin: /prd-evolve