### PR TITLE
fix(infra): change Docker PostgreSQL host port from 5432 to 5433

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # Database
-DATABASE_URL=postgresql://postgres:postgres_dev_password@localhost:5432/authority_highlighter
-DATABASE_URL_READER=postgresql://api_reader_user:reader_password_change_in_prod@localhost:5432/authority_highlighter
-DATABASE_URL_WRITER=postgresql://pipeline_admin_user:admin_password_change_in_prod@localhost:5432/authority_highlighter
+DATABASE_URL=postgresql://postgres:postgres_dev_password@localhost:5433/authority_highlighter
+DATABASE_URL_READER=postgresql://api_reader_user:reader_password_change_in_prod@localhost:5433/authority_highlighter
+DATABASE_URL_WRITER=postgresql://pipeline_admin_user:admin_password_change_in_prod@localhost:5433/authority_highlighter
 
 # Encryption
 CPF_ENCRYPTION_KEY=<32-byte-hex-encoded-aes256-key>

--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ pnpm install
 cp .env.example .env.local
 
 # Start PostgreSQL and infrastructure
+# PostgreSQL is exposed on host port 5433 (container port 5432)
+# This avoids conflicts with any local PostgreSQL installation on port 5432
 docker compose up -d
 
 # Run database migrations
@@ -127,6 +129,8 @@ pnpm --filter @pah/db migrate
 # Start development servers
 pnpm dev
 ```
+
+> **Port note:** Docker maps PostgreSQL to `localhost:5433` on the host (container still uses 5432 internally). If port 5433 is also unavailable on your machine, update `ports` in `docker-compose.yml` and the `DATABASE_URL*` variables in `.env.local` to use a free port.
 
 ### Environment Variables
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres_dev_password
     ports:
-      - "127.0.0.1:5432:5432"
+      - "127.0.0.1:5433:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
       - ./infrastructure/init-schemas.sql:/docker-entrypoint-initdb.d/01-schemas.sql


### PR DESCRIPTION
## Summary

- Port 5432 conflicts with local PostgreSQL installations in development environments, especially in WSL2, causing \`docker compose up -d\` to fail with \`ports are not available: /forwards/expose returned unexpected status: 500\`
- Changed Docker host port mapping from 5432 to 5433 to avoid the conflict while keeping the container's internal port as 5432
- Updated all connection strings in \`.env.example\` and README documentation

## Root Cause

The `docker-compose.yml` was binding PostgreSQL to `127.0.0.1:5432` on the host. In WSL2 environments (and any machine with a local PostgreSQL installation), port 5432 is typically already in use, causing Docker's port forwarding proxy to return a 500 error.

## Changes

| File | Change |
|------|--------|
| `docker-compose.yml` | Host port changed from `5432` to `5433` (container still uses `5432`) |
| `.env.example` | All `DATABASE_URL*` updated from `localhost:5432` to `localhost:5433` |
| `README.md` | Added port note in Setup section and override instructions |

## Testing

- [x] `docker compose config` validates correctly (host port 5433, target 5432)
- [x] Lint passes (`pnpm lint`)
- [x] No type changes — config-only fix

## Validation

```bash
# Validate compose config
docker compose config | grep -A5 ports
# Expected: published: "5433", target: 5432

# Start database
docker compose up -d
# Should succeed without port conflict

# Verify connection with new port
psql postgresql://postgres:postgres_dev_password@localhost:5433/authority_highlighter -c "SELECT 1"
```

---

_Automated fix for Docker port conflict in local development environment_