### PR TITLE
feat(web-frontend-design): add design enforcement skill and update docs

### DIFF
--- a/.agents/skills/project-architecture/SKILL.md
+++ b/.agents/skills/project-architecture/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: project-architecture
 description: Architecture enforcement during development. Use when creating files, database queries, adding dependencies, or modifying infrastructure.
-license: Apache-2.0
-version: 1.0.0
 ---
 
 # Project Architecture Enforcement
@@ -16,7 +14,7 @@ Enforces the architectural decisions documented in ARCHITECTURE.md and the 7 ADR
 ### 1. Two-Schema Database Separation (ADR-001)
 
 ```
-PostgreSQL (local: Supabase CLI supabase start, port 54322; roles via supabase/roles.sql)
+PostgreSQL 16
 ├── public schema (10 tables) — API reads from here
 │   ├── politicians, integrity_scores, bills, votes, expenses...
 │   └── data_source_status
@@ -91,6 +89,10 @@ All `tsconfig.json` files must include:
 - Static generation for methodology page
 - No client-side state management library (use URL search params + Server Components)
 - Tailwind CSS + shadcn/ui for UI components
+
+> **Design Enforcement:** For any work involving UI components, pages, or visual styles in `apps/web/`,
+> **REQUIRED SUB-SKILL:** `web-frontend-design`. This skill governs design tokens, typography,
+> responsiveness, component specs, and accessibility as defined in `docs/assets/frontend_design_prd.md`.
 
 ### 6. Managed Infrastructure on Supabase (ADR-006)
 

--- a/.agents/skills/project-domain-rules/SKILL.md
+++ b/.agents/skills/project-domain-rules/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: project-domain-rules
 description: Domain rule enforcement for Political Authority Highlighter. Use when writing business logic, scoring algorithms, data ingestion, or API endpoints.
-license: Apache-2.0
-version: 1.0.0
 ---
 
 # Domain Rules Enforcement
@@ -46,11 +44,15 @@ return { total: 513, excluded: 47, visible: 466 }
 
 **Rule:** The platform must NEVER exhibit political bias. Score methodology is identical across all parties, roles, and states. No editorializing.
 
+> For the **UI implementation** of color neutrality, **REQUIRED SUB-SKILL:** `web-frontend-design`
+> (section 1 — Design Token Enforcement defines the approved neutral palette and explicitly forbids
+> party-associated colors).
+
 ### Code Review Checklist
 
 - [ ] Score algorithm has NO party-specific logic (no `if party === 'PT'`)
 - [ ] Score weights are the same for all politicians regardless of party/state/role
-- [ ] UI uses neutral colors (no red/blue party associations)
+- [ ] UI uses neutral colors (no red/blue party associations) → see `web-frontend-design` token palette
 - [ ] Vote descriptions are factual (no "voted against the people" editorializing)
 - [ ] No hardcoded party names in scoring or display logic
 - [ ] Default sort is by score descending (not by party or ideology)

--- a/.agents/skills/project-guardian/SKILL.md
+++ b/.agents/skills/project-guardian/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: project-guardian
-description: Guardian skill that enforces PRD compliance during development. Use when implementing any feature, creating endpoints, or modifying UI.
-license: Apache-2.0
-version: 1.0.0
+description: Guardian skill that enforces PRD compliance during development. Use when implementing any feature, creating endpoints, or modifying UI. For any UI change in apps/web/, also requires web-frontend-design skill.
 ---
 
 # Project Guardian — PRD Compliance Enforcement
@@ -97,14 +95,20 @@ For any new API endpoint:
 
 ### 5. UI Neutrality Check
 
+**REQUIRED SUB-SKILL:** For ANY UI change in `apps/web/`, invoke `web-frontend-design` BEFORE writing code.
+The `web-frontend-design` skill enforces the full Frontend Design PRD (design tokens, typography,
+layout, component specs, accessibility). The checks below are the domain-level invariants; the
+design skill governs the visual and UX implementation.
+
 For any UI change:
 
-- [ ] Uses neutral color palette (no party colors)?
+- [ ] Uses neutral color palette (no party colors)? → See `web-frontend-design` for approved token palette
 - [ ] Presents data factually without qualitative judgment?
 - [ ] Default sort is by highest score (never by lowest)?
 - [ ] No "worst" or "bottom" ranking visible?
-- [ ] Mobile responsive (320px minimum)?
-- [ ] Accessibility: semantic HTML, aria labels, WCAG 2.1 AA?
+- [ ] Mobile responsive (320px minimum)? → See `web-frontend-design` for breakpoint rules
+- [ ] Accessibility: semantic HTML, aria labels, WCAG 2.1 AA? → See `web-frontend-design` section 5
+- [ ] Inspiration images consulted? (`docs/assets/inspirations/`)
 
 ### 6. Budget Impact Assessment
 
@@ -154,6 +158,20 @@ pnpm test              # All unit tests green
 > that typecheck does not. `vercel build` simulates the exact Vercel CI environment — if it fails
 > here, the CI pipeline rejects the PR. Both commands must pass before any PR is created.
 
+### 10. Post-PR Validation (Required)
+
+After creating a PR to `development`, validate the deploy:
+
+- **Automatic:** `validate-deploy.yml` triggers after `ci.yml` completes and posts a result
+  comment on the PR
+- **Manual (when needed):** invoke `/project-deploy-validator` in Claude Code
+
+Only consider implementation **COMPLETE** when all three are confirmed:
+
+- [ ] CI (`ci.yml`) passed on GitHub Actions
+- [ ] Vercel deploy confirmed (preview URL available on PR comment)
+- [ ] Supabase migrations applied without errors
+
 ## Violation Response
 
 If any check fails:
@@ -171,3 +189,4 @@ If any check fails:
 | 2026-03-07 | 1.1 | Add Frontend Security Check (section 7) for DR-008 enforcement |
 | 2026-03-09 | 1.2 | Schema rename public_data→public, Supabase Free tier |
 | 2026-03-14 | 1.2 | Add section 9: mandatory pnpm build + vercel build before any PR |
+| 2026-03-14 | 1.2 | Add section 10: post-PR validation via validate-deploy.yml and project-deploy-validator skill |

--- a/.agents/skills/web-testing/SKILL.md
+++ b/.agents/skills/web-testing/SKILL.md
@@ -40,38 +40,50 @@ npx lighthouse https://example.com     # Performance
 ## Reference Documentation
 
 ### Core Testing
+
 - `./references/unit-integration-testing.md` - Unit/integration patterns
 - `./references/e2e-testing-playwright.md` - Playwright E2E workflows
 - `./references/component-testing.md` - React/Vue/Angular component testing
 - `./references/testing-pyramid-strategy.md` - Test ratios, priority matrix
 
 ### Cross-Browser & Mobile
+
 - `./references/cross-browser-checklist.md` - Browser/device matrix
 - `./references/mobile-gesture-testing.md` - Touch, swipe, orientation
 - `./references/shadow-dom-testing.md` - Web components testing
 
 ### Interactive & Forms
+
 - `./references/interactive-testing-patterns.md` - Forms, keyboard, drag-drop
 - `./references/functional-testing-checklist.md` - Feature testing
 
 ### Performance & Quality
+
 - `./references/performance-core-web-vitals.md` - LCP/CLS/INP, Lighthouse CI
 - `./references/visual-regression.md` - Screenshot comparison
 - `./references/test-flakiness-mitigation.md` - Stability strategies
 
 ### Accessibility
+
 - `./references/accessibility-testing.md` - WCAG checklist, axe-core
 
+> When writing accessibility tests for `apps/web/`, consult `web-frontend-design` (section 5) for
+> the project-specific WCAG 2.1 AA requirements: focus ring specs, minimum touch targets (44×44px),
+> minimum font size (14px), and `aria-label` requirements for charts and score gauges.
+
 ### Security
+
 - `./references/security-testing-overview.md` - OWASP Top 10, tools
 - `./references/security-checklists.md` - Auth, API, headers
 - `./references/vulnerability-payloads.md` - SQL/XSS/CSRF payloads
 
 ### API & Load
+
 - `./references/api-testing.md` - API test patterns
 - `./references/load-testing-k6.md` - k6 load test patterns
 
 ### Checklists
+
 - `./references/pre-release-checklist.md` - Complete release checklist
 
 ## CI/CD Integration

--- a/.claude/skills/project-architecture/SKILL.md
+++ b/.claude/skills/project-architecture/SKILL.md
@@ -92,7 +92,7 @@ All `tsconfig.json` files must include:
 
 > **Design Enforcement:** For any work involving UI components, pages, or visual styles in `apps/web/`,
 > **REQUIRED SUB-SKILL:** `web-frontend-design`. This skill governs design tokens, typography,
-> responsiveness, component specs, and accessibility as defined in `docs/assets/frontend_design_prd.md`.
+> responsiveness, component specs, and accessibility as defined in `docs/prd/frontend_design_prd.md`.
 
 ### 6. Managed Infrastructure on Supabase (ADR-006)
 

--- a/.claude/skills/project-architecture/SKILL.md
+++ b/.claude/skills/project-architecture/SKILL.md
@@ -90,6 +90,10 @@ All `tsconfig.json` files must include:
 - No client-side state management library (use URL search params + Server Components)
 - Tailwind CSS + shadcn/ui for UI components
 
+> **Design Enforcement:** For any work involving UI components, pages, or visual styles in `apps/web/`,
+> **REQUIRED SUB-SKILL:** `web-frontend-design`. This skill governs design tokens, typography,
+> responsiveness, component specs, and accessibility as defined in `docs/assets/frontend_design_prd.md`.
+
 ### 6. Managed Infrastructure on Supabase (ADR-006)
 
 - Database on Supabase (Free tier, upgrade to Pro when needed)

--- a/.claude/skills/project-domain-rules/SKILL.md
+++ b/.claude/skills/project-domain-rules/SKILL.md
@@ -44,11 +44,15 @@ return { total: 513, excluded: 47, visible: 466 }
 
 **Rule:** The platform must NEVER exhibit political bias. Score methodology is identical across all parties, roles, and states. No editorializing.
 
+> For the **UI implementation** of color neutrality, **REQUIRED SUB-SKILL:** `web-frontend-design`
+> (section 1 — Design Token Enforcement defines the approved neutral palette and explicitly forbids
+> party-associated colors).
+
 ### Code Review Checklist
 
 - [ ] Score algorithm has NO party-specific logic (no `if party === 'PT'`)
 - [ ] Score weights are the same for all politicians regardless of party/state/role
-- [ ] UI uses neutral colors (no red/blue party associations)
+- [ ] UI uses neutral colors (no red/blue party associations) → see `web-frontend-design` token palette
 - [ ] Vote descriptions are factual (no "voted against the people" editorializing)
 - [ ] No hardcoded party names in scoring or display logic
 - [ ] Default sort is by score descending (not by party or ideology)

--- a/.claude/skills/project-guardian/SKILL.md
+++ b/.claude/skills/project-guardian/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: project-guardian
-description: Guardian skill that enforces PRD compliance during development. Use when implementing any feature, creating endpoints, or modifying UI.
+description: Guardian skill that enforces PRD compliance during development. Use when implementing any feature, creating endpoints, or modifying UI. For any UI change in apps/web/, also requires web-frontend-design skill.
 ---
 
 # Project Guardian — PRD Compliance Enforcement
@@ -95,14 +95,20 @@ For any new API endpoint:
 
 ### 5. UI Neutrality Check
 
+**REQUIRED SUB-SKILL:** For ANY UI change in `apps/web/`, invoke `web-frontend-design` BEFORE writing code.
+The `web-frontend-design` skill enforces the full Frontend Design PRD (design tokens, typography,
+layout, component specs, accessibility). The checks below are the domain-level invariants; the
+design skill governs the visual and UX implementation.
+
 For any UI change:
 
-- [ ] Uses neutral color palette (no party colors)?
+- [ ] Uses neutral color palette (no party colors)? → See `web-frontend-design` for approved token palette
 - [ ] Presents data factually without qualitative judgment?
 - [ ] Default sort is by highest score (never by lowest)?
 - [ ] No "worst" or "bottom" ranking visible?
-- [ ] Mobile responsive (320px minimum)?
-- [ ] Accessibility: semantic HTML, aria labels, WCAG 2.1 AA?
+- [ ] Mobile responsive (320px minimum)? → See `web-frontend-design` for breakpoint rules
+- [ ] Accessibility: semantic HTML, aria labels, WCAG 2.1 AA? → See `web-frontend-design` section 5
+- [ ] Inspiration images consulted? (`docs/assets/inspirations/`)
 
 ### 6. Budget Impact Assessment
 

--- a/.claude/skills/web-frontend-design/SKILL.md
+++ b/.claude/skills/web-frontend-design/SKILL.md
@@ -1,0 +1,262 @@
+---
+name: web-frontend-design
+description: Use when creating, modifying, or reviewing any UI component, page, layout, or visual style in apps/web/ — enforces the Frontend Design PRD design tokens, color palette, typography, layout rules, component specs, and accessibility standards. Triggers on any apps/web/ changes involving JSX, CSS, Tailwind classes, or new components.
+---
+
+# Web Frontend Design Enforcement
+
+## Critical Rule — No Exceptions
+
+**Every implementation touching `apps/web/` UI MUST comply with the Frontend Design PRD at `docs/assets/frontend_design_prd.md` and draw inspiration from `docs/assets/inspirations/`.**
+
+Violating the letter of these rules is violating the spirit of the rules.
+
+```dot
+digraph design_enforcement {
+    "UI change in apps/web/?" [shape=diamond];
+    "Read PRD + check inspiration images" [shape=box];
+    "Apply design checklist" [shape=box];
+    "All checks pass?" [shape=diamond];
+    "STOP — fix violations" [shape=box];
+    "Proceed to build" [shape=box];
+
+    "UI change in apps/web/?" -> "Read PRD + check inspiration images" [label="yes"];
+    "Read PRD + check inspiration images" -> "Apply design checklist";
+    "Apply design checklist" -> "All checks pass?" ;
+    "All checks pass?" -> "STOP — fix violations" [label="no"];
+    "All checks pass?" -> "Proceed to build" [label="yes"];
+    "STOP — fix violations" -> "Apply design checklist";
+}
+```
+
+---
+
+## 1. Design Token Enforcement
+
+Before writing a single Tailwind class, verify every token maps to the PRD palette.
+
+### Colors — Use ONLY these semantic tokens
+
+| Semantic Role | Light Mode | Dark Mode | Tailwind Class |
+|---|---|---|---|
+| Background Base | `#FFFFFF` | `#0B0E14` | `bg-white` / `dark:bg-[#0B0E14]` |
+| Surface/Card | `#F8FAFC` | `#161B22` | `bg-slate-50` / `dark:bg-[#161B22]` |
+| Border/Divider | `#E2E8F0` | `#30363D` | `border-slate-200` / `dark:border-[#30363D]` |
+| Primary (Trust Blue) | `#1D4ED8` | `#3B82F6` | `text-blue-700` / `dark:text-blue-500` |
+| Success (Integrity Green) | `#16A34A` | `#22C55E` | `text-green-600` / `dark:text-green-500` |
+| Warning/Accent (Yellow) | `#D97706` | `#FACC15` | `text-amber-600` / `dark:text-yellow-400` |
+| Text Primary | `#0F172A` | `#F8FAFC` | `text-slate-900` / `dark:text-slate-50` |
+| Text Muted | `#64748B` | `#94A3B8` | `text-slate-500` / `dark:text-slate-400` |
+
+**REJECT any color outside this palette** unless explicitly justified.
+
+**NEVER use party colors** (red/blue political associations, warm reds, strong partisan tones).
+
+### Typography
+
+- **UI/Reading font:** `Inter` or `Plus Jakarta Sans` — apply to all body text, headings, labels
+- **Data/Numbers font:** `JetBrains Mono` or `Roboto Mono` — use ONLY for integrity scores, financial values, process numbers
+- **Minimum font size:** `14px` (`text-sm`) — never below this
+- **Base size:** `16px` (`text-base`)
+- **Headings:** `font-bold` or `font-extrabold` + `tracking-tight`
+
+### Spacing & Border Radius
+
+- **Spacing:** Strict 4px grid — `p-4`, `m-6`, `gap-8` etc. (Tailwind defaults)
+- **Cards/Containers:** `rounded-2xl` or `rounded-xl`
+- **Buttons/Badges:** `rounded-lg` or `rounded-md`
+- **Tags/Pills:** `rounded-full`
+
+---
+
+## 2. Layout & Responsiveness
+
+| Breakpoint | Grid | Navigation |
+|---|---|---|
+| Mobile `< 640px` | `grid-cols-1` | Bottom Tab Bar (44px touch targets) |
+| Tablet `640–1024px` | 2-column Bento Grid | Collapsible side drawer |
+| Desktop `> 1024px` | 3–4 column Bento Grid | Fixed left sidebar (280px wide) |
+
+- Main content area: `max-w-7xl` on desktop
+- Header: Glassmorphism sticky — `backdrop-blur-md bg-white/70 dark:bg-[#0B0E14]/70`
+- Complex tables → stacked vertical cards on mobile
+- Sidebars → Bottom Tab Navigation on mobile
+
+---
+
+## 3. Component-Specific Rules
+
+### Politician Profile Card (Bento Grid)
+
+- Avatar: `rounded-full`
+- Name: `<h2>` with bold weight
+- Role: `text-muted` class
+- Integrity Gauge: Semi-circle SVG, stroke color → Green if score ≥ 80, Yellow if 50–79, otherwise muted. Center number uses `JetBrains Mono`
+- Tags: `bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400 rounded-full`
+
+### Data Tables
+
+- No inner borders; rows separated by `border-b border-slate-200 dark:border-slate-800`
+- Row hover: `hover:bg-slate-50 dark:hover:bg-white/5`
+- Actions: right-aligned chevron icon
+- Mobile: convert to stacked cards
+
+### Buttons
+
+- **Primary:** `bg-blue-600 text-white shadow-sm rounded-lg`
+- **Secondary:** `border border-slate-300 bg-transparent rounded-lg`
+- **Hover:** `hover:-translate-y-[1px] transition-all duration-200 ease-in-out`
+- All interactive states required: `default`, `hover`, `focus`, `active`, `disabled`
+- Focus ring: `focus:ring-2 focus:ring-blue-500 focus:outline-none`
+
+---
+
+## 4. Motion & Micro-Interactions
+
+- **Page transitions:** Fade `opacity-0 → opacity-100` over `300ms`
+- **Loading:** Skeleton screens (`animate-pulse bg-slate-200 dark:bg-slate-800`) matching content shape — **NEVER generic spinners** for main content
+- **Tooltips:** Dark background, `duration-150` fade-in, trigger on `hover` (desktop) / `tap` (mobile)
+
+---
+
+## 5. Accessibility (WCAG 2.1 AA — Mandatory)
+
+- [ ] All charts, icons, and interactive elements have descriptive `aria-label`
+- [ ] Minimum touch target: `44×44px` (especially mobile nav)
+- [ ] Keyboard navigation fully supported
+- [ ] Focus rings visible and high-contrast: `focus:ring-2 focus:ring-blue-500 focus:outline-none`
+- [ ] Font size never below `14px`
+- [ ] Contrast ratio ≥ 4.5:1 for text (WCAG AA)
+- [ ] Language: neutral, educational, no legal jargon ("juridiquês")
+
+---
+
+## 6. UX Copywriting Rules
+
+- Tone: neutral, educational, optimistic
+- Target reading level: average Brazilian citizen
+- Use tooltips to explain civic/legal terminology instead of showing raw jargon
+- Example: use "Condenação por mau uso de dinheiro público" with a tooltip instead of raw "Ato de Improbidade Administrativa"
+
+---
+
+## 7. Design Checklist (Run Before Every UI PR)
+
+**Color & Theme**
+
+- [ ] All colors use PRD semantic tokens only
+- [ ] Dark mode variants defined for every color token used
+- [ ] No party-associated colors
+
+**Typography**
+
+- [ ] UI text uses Inter or Plus Jakarta Sans
+- [ ] Scores/numbers use JetBrains Mono or Roboto Mono
+- [ ] No font size below `text-sm` (14px)
+
+**Layout**
+
+- [ ] Mobile-first: works at 320px minimum width
+- [ ] Responsive breakpoints: 1-col mobile → 2-col tablet → 3-4 col desktop
+- [ ] Sidebar converts to Bottom Tab on mobile
+
+**Components**
+
+- [ ] All interactive states implemented (hover, focus, active, disabled)
+- [ ] Cards use `rounded-xl` or `rounded-2xl`
+- [ ] Buttons follow primary/secondary specs
+- [ ] Table rows have correct hover state
+
+**Accessibility**
+
+- [ ] `aria-label` on all icons, charts, interactive elements
+- [ ] Touch targets ≥ 44×44px
+- [ ] Focus rings present and visible
+- [ ] No generic spinners for main content loads
+
+**Vibe Check**
+
+- [ ] Matches modern SaaS aesthetic (NOT legacy government portal)
+- [ ] Clean lines, subtle glassmorphism in header
+- [ ] Data is the hero — score visible first, details behind progressive disclosure
+- [ ] Compare against inspiration images in `docs/assets/inspirations/` before submitting
+
+---
+
+## 8. Inspiration References
+
+### 8.1 Local Inspiration Images
+
+Study the images in `docs/assets/inspirations/` before implementing:
+
+| Category | Path | Use For |
+|---|---|---|
+| Profiles | `docs/assets/inspirations/profile/` | Score gauges, bento grid layout, stat cards |
+| Components | `docs/assets/inspirations/components/` | Tables, lists, sidebars, headers, footers |
+| Homepage | `docs/assets/inspirations/homepage/` | Hero sections, call-to-action layouts |
+
+Key patterns observed:
+
+- Clean sidebar with icon + text nav, subtle active state highlight
+- Data tables with avatar column, status badges (`rounded-full`), right-aligned actions
+- Score/gauge charts centered in profile bento cards with number below
+- Stats displayed as large mono-font numbers with muted labels
+- Glassmorphism header with centered or left-aligned logo
+
+### 8.2 Sloth UI — Figma Design Reference
+
+**Sloth UI** (<https://www.slothui.com/>) is a Figma-based atomic design kit with a modern minimalist
+SaaS-dashboard aesthetic, WCAG 2.1 accessible defaults, dark/light mode variants, and Phosphor icons.
+
+**When to use:** Consult it when planning the visual layout of a new page or complex component
+_before_ writing code. It helps visualise spacing, hierarchy, and component variants in Figma-style
+mockups.
+
+**How to use:**
+
+1. Browse <https://www.slothui.com/> for component anatomy, layout patterns, and atomic design conventions
+2. Extract the visual patterns (spacing rhythm, card hierarchy, icon treatment) and map them to the
+   PRD design tokens from this skill
+3. **Do NOT import SlothUI as a code dependency** — it is Figma-only with no npm package or Tailwind
+   integration. All code implementation must use Tailwind CSS + shadcn/ui following the PRD tokens
+
+**Useful for this project:**
+
+- Gauge/score card anatomy and spacing
+- Sidebar nav active-state treatment
+- Data-dense dashboard bento cell proportions
+- Button and badge variant mapping
+
+---
+
+## 9. Red Flags — STOP and Redesign
+
+| What you're about to do | Why it's wrong |
+|---|---|
+| "I'll add the dark mode styles later" | Dark mode is mandatory now, not after |
+| "The spinner is good enough for loading" | Skeleton screens are required for main content |
+| "This color looks close enough" | Only exact PRD tokens are allowed |
+| "The mobile layout is basically the same as desktop" | Mobile-first means designed for mobile first |
+| "I'll add aria-labels in a later pass" | Accessibility is a first-class requirement |
+| "This is a small component, the PRD doesn't apply" | The PRD applies to EVERY UI element, no size exceptions |
+| "I'll use a party color to distinguish politicians" | Party colors are forbidden — DR-002: Political Neutrality |
+
+---
+
+## 10. Full PRD Reference
+
+The complete Frontend Design PRD (design tokens, typography scale, component specs, responsiveness rules) is at:
+
+```
+docs/assets/frontend_design_prd.md
+```
+
+Read it before implementing any new page or component. It is the authoritative source.
+
+---
+
+## Changelog
+
+| Date | Summary |
+|------|---------|
+| 2026-03-15 | Initial skill — enforces Frontend Design PRD v1.0 compliance across apps/web/ |

--- a/.claude/skills/web-frontend-design/SKILL.md
+++ b/.claude/skills/web-frontend-design/SKILL.md
@@ -7,7 +7,7 @@ description: Use when creating, modifying, or reviewing any UI component, page, 
 
 ## Critical Rule — No Exceptions
 
-**Every implementation touching `apps/web/` UI MUST comply with the Frontend Design PRD at `docs/assets/frontend_design_prd.md` and draw inspiration from `docs/assets/inspirations/`.**
+**Every implementation touching `apps/web/` UI MUST comply with the Frontend Design PRD at `docs/prd/frontend_design_prd.md` and draw inspiration from `docs/assets/inspirations/`.**
 
 Violating the letter of these rules is violating the spirit of the rules.
 
@@ -248,7 +248,7 @@ mockups.
 The complete Frontend Design PRD (design tokens, typography scale, component specs, responsiveness rules) is at:
 
 ```
-docs/assets/frontend_design_prd.md
+docs/prd/frontend_design_prd.md
 ```
 
 Read it before implementing any new page or component. It is the authoritative source.

--- a/.github/workflows/validate-deploy.yml
+++ b/.github/workflows/validate-deploy.yml
@@ -2,7 +2,7 @@ name: Validate Deploy
 
 on:
   workflow_run:
-    workflows: ["CI", "Deploy staging CI"]
+    workflows: ["CI"]
     branches: [development]
     types: [completed]
 

--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ tmp/
 .agents/
 
 .claude/settings.json
+docs/assets/inspirations/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -384,7 +384,7 @@ Before opening a pull request, verify:
 - [ ] Public-facing text is politically neutral and factual
 - [ ] New API endpoints include request/response schemas with TypeBox
 - [ ] New components are accessible (keyboard navigable, proper ARIA attributes)
-- [ ] UI changes reviewed against `docs/assets/frontend_design_prd.md` (design tokens, typography, dark mode, component specs) — run `web-frontend-design` skill checklist
+- [ ] UI changes reviewed against `docs/prd/frontend_design_prd.md` (design tokens, typography, dark mode, component specs) — run `web-frontend-design` skill checklist
 - [ ] Conventional commit message format used
 
 ---
@@ -394,7 +394,7 @@ Before opening a pull request, verify:
 | Layer                    | Guide Location             | Scope                                                                 |
 | ------------------------ | -------------------------- | --------------------------------------------------------------------- |
 | Backend (API + Pipeline) | `apps/api/CLAUDE.md`       | Fastify routes, services, Drizzle queries, pipeline adapters, scoring |
-| Frontend                 | `apps/web/CLAUDE.md`       | Next.js pages, components, ISR, SEO, accessibility, **Frontend Design PRD compliance** (`docs/assets/frontend_design_prd.md`) |
+| Frontend                 | `apps/web/CLAUDE.md`       | Next.js pages, components, ISR, SEO, accessibility, **Frontend Design PRD compliance** (`docs/prd/frontend_design_prd.md`) |
 | Infrastructure           | `infrastructure/CLAUDE.md` | Supabase CLI local, Docker optional, CI/CD, monitoring                |
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -384,6 +384,7 @@ Before opening a pull request, verify:
 - [ ] Public-facing text is politically neutral and factual
 - [ ] New API endpoints include request/response schemas with TypeBox
 - [ ] New components are accessible (keyboard navigable, proper ARIA attributes)
+- [ ] UI changes reviewed against `docs/assets/frontend_design_prd.md` (design tokens, typography, dark mode, component specs) — run `web-frontend-design` skill checklist
 - [ ] Conventional commit message format used
 
 ---
@@ -393,7 +394,7 @@ Before opening a pull request, verify:
 | Layer                    | Guide Location             | Scope                                                                 |
 | ------------------------ | -------------------------- | --------------------------------------------------------------------- |
 | Backend (API + Pipeline) | `apps/api/CLAUDE.md`       | Fastify routes, services, Drizzle queries, pipeline adapters, scoring |
-| Frontend                 | `apps/web/CLAUDE.md`       | Next.js pages, components, ISR, SEO, accessibility                    |
+| Frontend                 | `apps/web/CLAUDE.md`       | Next.js pages, components, ISR, SEO, accessibility, **Frontend Design PRD compliance** (`docs/assets/frontend_design_prd.md`) |
 | Infrastructure           | `infrastructure/CLAUDE.md` | Supabase CLI local, Docker optional, CI/CD, monitoring                |
 
 ---
@@ -404,3 +405,4 @@ Before opening a pull request, verify:
 | ---------- | ----------- | ----------------------------------------------------- |
 | 2026-02-28 | 1.0         | Initial project-wide development guide                |
 | 2026-03-09 | 1.2         | Supabase Free tier, schema rename public_data->public |
+| 2026-03-15 | 1.2         | Add `web-frontend-design` skill to Pre-PR Checklist; update Frontend layer guide to reference Frontend Design PRD |

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -38,7 +38,7 @@ The project is a **Modular Monolith** organized as a TypeScript monorepo using *
 ## Critical Domain Rules (Non-Negotiable)
 
 - **DR-001: Silent Exclusion**: The public API/frontend must **never** expose why an anticorruption score is 0. Only a boolean `exclusion_flag` crosses the schema boundary.
-- **DR-002: Political Neutrality**: No party colors in UI. Neutral palette (authoritative token set: `docs/assets/frontend_design_prd.md`). Factual language only (no "best/worst" labels). All `apps/web/` UI must comply with the Frontend Design PRD — design tokens, typography (`Inter`/`Plus Jakarta Sans` for UI; `JetBrains Mono` for scores/numbers), dark mode, Bento Grid layout, and component specs are non-negotiable.
+- **DR-002: Political Neutrality**: No party colors in UI. Neutral palette (authoritative token set: `docs/prd/frontend_design_prd.md`). Factual language only (no "best/worst" labels). All `apps/web/` UI must comply with the Frontend Design PRD — design tokens, typography (`Inter`/`Plus Jakarta Sans` for UI; `JetBrains Mono` for scores/numbers), dark mode, Bento Grid layout, and component specs are non-negotiable.
 - **DR-005: CPF Protection**: CPFs must be encrypted (AES-256-GCM) at rest and never exposed in logs, error messages, or API responses.
 - **DR-006: Schema Isolation**: The `api_reader` role has **zero access** to the `internal_data` schema. This isolation is enforced at the database level.
 
@@ -78,7 +78,7 @@ When working in this codebase, prioritize:
 3. **Security Awareness**: Never inadvertently expose internal schema fields or unencrypted identifiers.
 4. **Neutral Tone**: Maintain the project's commitment to political neutrality in all UI and documentation updates.
 5. **Mandatory Validation**: Before claiming any task is complete, run `pnpm build` AND `vercel build`. Both must pass. `pnpm typecheck` alone is insufficient — `pnpm build` catches Next.js compilation errors and `vercel build` catches Vercel-specific issues that CI will reject.
-6. **Frontend Design Compliance**: Any UI change in `apps/web/` must comply with `docs/assets/frontend_design_prd.md`. Consult the `web-frontend-design` skill checklist before every UI PR. For visual inspiration, use the images in `docs/assets/inspirations/` and [Sloth UI](https://www.slothui.com/) (Figma-only — reference only, not a code dependency).
+6. **Frontend Design Compliance**: Any UI change in `apps/web/` must comply with `docs/prd/frontend_design_prd.md`. Consult the `web-frontend-design` skill checklist before every UI PR. For visual inspiration, use the images in `docs/assets/inspirations/` and [Sloth UI](https://www.slothui.com/) (Figma-only — reference only, not a code dependency).
 
 ---
 *Last Updated: 2026-03-15*

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -38,7 +38,7 @@ The project is a **Modular Monolith** organized as a TypeScript monorepo using *
 ## Critical Domain Rules (Non-Negotiable)
 
 - **DR-001: Silent Exclusion**: The public API/frontend must **never** expose why an anticorruption score is 0. Only a boolean `exclusion_flag` crosses the schema boundary.
-- **DR-002: Political Neutrality**: No party colors in UI. Neutral palette. Factual language only (no "best/worst" labels).
+- **DR-002: Political Neutrality**: No party colors in UI. Neutral palette (authoritative token set: `docs/assets/frontend_design_prd.md`). Factual language only (no "best/worst" labels). All `apps/web/` UI must comply with the Frontend Design PRD — design tokens, typography (`Inter`/`Plus Jakarta Sans` for UI; `JetBrains Mono` for scores/numbers), dark mode, Bento Grid layout, and component specs are non-negotiable.
 - **DR-005: CPF Protection**: CPFs must be encrypted (AES-256-GCM) at rest and never exposed in logs, error messages, or API responses.
 - **DR-006: Schema Isolation**: The `api_reader` role has **zero access** to the `internal_data` schema. This isolation is enforced at the database level.
 
@@ -78,6 +78,7 @@ When working in this codebase, prioritize:
 3. **Security Awareness**: Never inadvertently expose internal schema fields or unencrypted identifiers.
 4. **Neutral Tone**: Maintain the project's commitment to political neutrality in all UI and documentation updates.
 5. **Mandatory Validation**: Before claiming any task is complete, run `pnpm build` AND `vercel build`. Both must pass. `pnpm typecheck` alone is insufficient — `pnpm build` catches Next.js compilation errors and `vercel build` catches Vercel-specific issues that CI will reject.
+6. **Frontend Design Compliance**: Any UI change in `apps/web/` must comply with `docs/assets/frontend_design_prd.md`. Consult the `web-frontend-design` skill checklist before every UI PR. For visual inspiration, use the images in `docs/assets/inspirations/` and [Sloth UI](https://www.slothui.com/) (Figma-only — reference only, not a code dependency).
 
 ---
-*Last Updated: 2026-03-14*
+*Last Updated: 2026-03-15*

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ pnpm test:e2e     # Run Playwright E2E tests
 - [PRD](docs/prd/PRD.md)
 - [Architecture](docs/prd/ARCHITECTURE.md)
 - [ER Diagram](docs/prd/ER.md)
-- [Frontend Design PRD](docs/assets/frontend_design_prd.md)
+- [Frontend Design PRD](docs/prd/frontend_design_prd.md)
 - [CLAUDE.md](CLAUDE.md)
 
 ## Status

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ pnpm test:e2e     # Run Playwright E2E tests
 - [PRD](docs/prd/PRD.md)
 - [Architecture](docs/prd/ARCHITECTURE.md)
 - [ER Diagram](docs/prd/ER.md)
+- [Frontend Design PRD](docs/assets/frontend_design_prd.md)
 - [CLAUDE.md](CLAUDE.md)
 
 ## Status

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -19,6 +19,8 @@
 
 5. **Mobile-First Responsive Design**: Tailwind breakpoints start at 320px minimum viewport. Design for mobile first, enhance for desktop. Touch targets minimum 44x44px. No horizontal scrolling on any screen size.
 
+6. **Frontend Design PRD Compliance (Non-Negotiable)**: Every component, page, or visual style change in `apps/web/` must comply with `docs/assets/frontend_design_prd.md`. This document is the authoritative source for design tokens, color palette (semantic roles with light/dark variants), typography (`Inter`/`Plus Jakarta Sans` for UI text; `JetBrains Mono` for scores and financial numbers), Bento Grid layout, component specifications (gauge charts, data tables, buttons), motion rules, and accessibility requirements. Before implementing any new page or component, consult the inspiration images in `docs/assets/inspirations/` and [Sloth UI](https://www.slothui.com/) for visual reference. **Run the `web-frontend-design` skill checklist before every UI PR.**
+
 ---
 
 ## Architecture Boundaries
@@ -489,6 +491,11 @@ export async function fetchPoliticianBySlug(
 
 ## UI Conventions
 
+> **Design Authority**: The canonical design token set, typography rules, component specs, and
+> responsiveness requirements live in `docs/assets/frontend_design_prd.md`. The color palette and
+> layout patterns below are a working summary — when there is any conflict, the PRD is authoritative.
+> For visual reference, consult `docs/assets/inspirations/` and [Sloth UI](https://www.slothui.com/).
+
 ### Tailwind CSS
 
 - Use Tailwind utility classes exclusively. No custom CSS except for Tailwind `@layer` extensions in `globals.css`.
@@ -832,11 +839,11 @@ test('politician profile page has no accessibility violations', async ({ page })
 
 3. **Use `next/image`** for all images. Set explicit `width`/`height` to prevent CLS. Use `priority` for above-the-fold images.
 
-3. **Dynamic import** interactive components (charts, maps) with `next/dynamic` and `{ ssr: false }` when they are below the fold.
+4. **Dynamic import** interactive components (charts, maps) with `next/dynamic` and `{ ssr: false }` when they are below the fold.
 
-4. **No barrel exports** (`index.ts` that re-exports everything from a directory). They prevent tree-shaking.
+5. **No barrel exports** (`index.ts` that re-exports everything from a directory). They prevent tree-shaking.
 
-5. **Preload critical API calls** using React `cache()` function to deduplicate fetch calls within a single render.
+6. **Preload critical API calls** using React `cache()` function to deduplicate fetch calls within a single render.
 
 ```typescript
 import { cache } from 'react'
@@ -943,6 +950,7 @@ describe('ScoreBadge', () => {
 | Import `@pah/db`, `pg`, or `drizzle-orm` in frontend            | Violates RNF-SEC-012/DR-008. Frontend accesses data through the API only                           |
 | Use `NEXT_PUBLIC_` prefix for secrets/tokens                    | Violates RNF-SEC-012. Only `NEXT_PUBLIC_API_URL` is permitted                                      |
 | Expose server error details in UI                               | Violates RNF-SEC-014. Error boundaries show generic messages; use `digest` for correlation         |
+| Implement UI without reading `docs/assets/frontend_design_prd.md` | Design tokens, typography, dark mode variants, component specs, and motion rules are defined there — skip it and you will introduce visual inconsistencies |
 
 ---
 
@@ -1036,3 +1044,4 @@ const securityHeaders = [
 | ---------- | ----------- | ------------------------------------------------------------------------------------------------------------------------- |
 | 2026-02-28 | 1.0         | Initial frontend development guide                                                                                        |
 | 2026-03-07 | 1.1         | Add Frontend Security First principle (DR-008), full CSP header, client bundle protection, error sanitization, SRI policy |
+| 2026-03-15 | 1.2         | Add principle 6: Frontend Design PRD compliance (`docs/assets/frontend_design_prd.md`); add UI Conventions design authority note; add anti-pattern for skipping PRD; add Sloth UI as visual reference |

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -19,7 +19,7 @@
 
 5. **Mobile-First Responsive Design**: Tailwind breakpoints start at 320px minimum viewport. Design for mobile first, enhance for desktop. Touch targets minimum 44x44px. No horizontal scrolling on any screen size.
 
-6. **Frontend Design PRD Compliance (Non-Negotiable)**: Every component, page, or visual style change in `apps/web/` must comply with `docs/assets/frontend_design_prd.md`. This document is the authoritative source for design tokens, color palette (semantic roles with light/dark variants), typography (`Inter`/`Plus Jakarta Sans` for UI text; `JetBrains Mono` for scores and financial numbers), Bento Grid layout, component specifications (gauge charts, data tables, buttons), motion rules, and accessibility requirements. Before implementing any new page or component, consult the inspiration images in `docs/assets/inspirations/` and [Sloth UI](https://www.slothui.com/) for visual reference. **Run the `web-frontend-design` skill checklist before every UI PR.**
+6. **Frontend Design PRD Compliance (Non-Negotiable)**: Every component, page, or visual style change in `apps/web/` must comply with `docs/prd/frontend_design_prd.md`. This document is the authoritative source for design tokens, color palette (semantic roles with light/dark variants), typography (`Inter`/`Plus Jakarta Sans` for UI text; `JetBrains Mono` for scores and financial numbers), Bento Grid layout, component specifications (gauge charts, data tables, buttons), motion rules, and accessibility requirements. Before implementing any new page or component, consult the inspiration images in `docs/assets/inspirations/` and [Sloth UI](https://www.slothui.com/) for visual reference. **Run the `web-frontend-design` skill checklist before every UI PR.**
 
 ---
 
@@ -492,7 +492,7 @@ export async function fetchPoliticianBySlug(
 ## UI Conventions
 
 > **Design Authority**: The canonical design token set, typography rules, component specs, and
-> responsiveness requirements live in `docs/assets/frontend_design_prd.md`. The color palette and
+> responsiveness requirements live in `docs/prd/frontend_design_prd.md`. The color palette and
 > layout patterns below are a working summary — when there is any conflict, the PRD is authoritative.
 > For visual reference, consult `docs/assets/inspirations/` and [Sloth UI](https://www.slothui.com/).
 
@@ -950,7 +950,7 @@ describe('ScoreBadge', () => {
 | Import `@pah/db`, `pg`, or `drizzle-orm` in frontend            | Violates RNF-SEC-012/DR-008. Frontend accesses data through the API only                           |
 | Use `NEXT_PUBLIC_` prefix for secrets/tokens                    | Violates RNF-SEC-012. Only `NEXT_PUBLIC_API_URL` is permitted                                      |
 | Expose server error details in UI                               | Violates RNF-SEC-014. Error boundaries show generic messages; use `digest` for correlation         |
-| Implement UI without reading `docs/assets/frontend_design_prd.md` | Design tokens, typography, dark mode variants, component specs, and motion rules are defined there — skip it and you will introduce visual inconsistencies |
+| Implement UI without reading `docs/prd/frontend_design_prd.md` | Design tokens, typography, dark mode variants, component specs, and motion rules are defined there — skip it and you will introduce visual inconsistencies |
 
 ---
 
@@ -1044,4 +1044,4 @@ const securityHeaders = [
 | ---------- | ----------- | ------------------------------------------------------------------------------------------------------------------------- |
 | 2026-02-28 | 1.0         | Initial frontend development guide                                                                                        |
 | 2026-03-07 | 1.1         | Add Frontend Security First principle (DR-008), full CSP header, client bundle protection, error sanitization, SRI policy |
-| 2026-03-15 | 1.2         | Add principle 6: Frontend Design PRD compliance (`docs/assets/frontend_design_prd.md`); add UI Conventions design authority note; add anti-pattern for skipping PRD; add Sloth UI as visual reference |
+| 2026-03-15 | 1.2         | Add principle 6: Frontend Design PRD compliance (`docs/prd/frontend_design_prd.md`); add UI Conventions design authority note; add anti-pattern for skipping PRD; add Sloth UI as visual reference |

--- a/docs/prd/frontend_design_prd.md
+++ b/docs/prd/frontend_design_prd.md
@@ -1,0 +1,135 @@
+# Project Requirements Document (PRD) & AI Design System Directives
+
+**Project Name:** Positive Transparency Portal (Portal da Transparência Positiva)
+**Document Purpose:** System prompt, architectural guideline, and behavioral rulebook for AI Coding Agents (e.g., Claude Code, Gemini) executing UI/UX and frontend engineering tasks.
+**Target Audience:** General Brazilian Public (Mobile-first, highly accessible, simplified civic engagement).
+
+---
+
+## 1. AI Agent Behavioral Directives
+
+As an AI acting on this project, you are expected to operate as a **rigorous intellectual partner and senior frontend engineer**, not a submissive assistant. When generating code or suggesting UI patterns, you must strictly adhere to the following behavioral rules:
+
+* **Constructive Rigor:** Do not blindly agree with initial human prompts if they violate accessibility, mobile-responsiveness, or modern UI best practices. If a requested layout is flawed for the target audience, flag it and propose the optimal alternative.
+* **Prioritize Truth and Usability:** Your goal is clarity, precision, and intellectual honesty. If a design choice obscures data or makes navigation complex for a low-literacy user, reject it and provide a better solution.
+* **Strong Opinions, Weakly Held:** Provide the single best implementation for a component rather than five mediocre options. Test assumptions logically before generating the code.
+* **Vibe Adherence:** You are generating a modern, high-trust, SaaS-like interface ("Vibe Coding"). Do not generate legacy government-style UIs (e.g., heavy drop shadows, cluttered navbars, dense legal jargon).
+
+---
+
+## 2. Core Design Philosophy
+
+The mission of this platform is to shift the Brazilian political narrative from "hunting corruption" to "highlighting integrity." The design must evoke **trust, modernity, and extreme simplicity**.
+
+* **Simplicity Over Complexity:** The primary user might be accessing this on a low-end smartphone on a 3G network. Data must be digestible at a glance.
+* **Data as the Hero:** Use progressive disclosure. Show the "Integrity Score" and a clean gauge chart first. Hide complex legislative history behind "View Details" interactions.
+* **The "Vibe" Aesthetic:** Clean lines, subtle glassmorphism, bento grids for data visualization, high-contrast borders, and deep, immersive dark modes.
+
+---
+
+## 3. Design Tokens & Theming
+
+The color palette is derived from the Brazilian Flag (Green, Yellow, Blue, White) but strictly adapted for digital UI/UX compliance (WCAG AA minimum contrast). Do not use the raw, saturated flag colors for backgrounds or text. Use the defined semantic tokens below.
+
+### 3.1. Color Palette (Tailwind CSS Semantic Mapping)
+
+| Semantic Role | Light Mode (Hex) | Dark Mode (Hex) | Usage Guidelines |
+| --- | --- | --- | --- |
+| **Background Base** | `#FFFFFF` | `#0B0E14` | Main application background. |
+| **Surface/Card** | `#F8FAFC` | `#161B22` | Background for Bento Grid cards, sidebars, modals. |
+| **Border/Divider** | `#E2E8F0` | `#30363D` | Subtle dividers, card outlines (1px solid). |
+| **Primary (Trust Blue)** | `#1D4ED8` | `#3B82F6` | Primary buttons, active tabs, standard links. |
+| **Success (Integrity Green)** | `#16A34A` | `#22C55E` | "Clean Record" badges, positive scores, progress bars. |
+| **Warning/Accent (Yellow)** | `#D97706` | `#FACC15` | Highlighted terms, attention-requiring tooltips, star ratings. |
+| **Text Primary** | `#0F172A` | `#F8FAFC` | Main body text, headings. |
+| **Text Muted** | `#64748B` | `#94A3B8` | Subtitles, table headers, metadata. |
+
+### 3.2. Typography Scale
+
+* **Font Family (UI/Reading):** `Inter` or `Plus Jakarta Sans` (Sans-serif, clean, highly legible).
+* **Font Family (Data/Numbers):** `JetBrains Mono` or `Roboto Mono` (Used strictly for integrity scores, financial data, and process numbers to enforce the "analytical" vibe).
+* **Base Size:** `16px` (`1rem`). Never go below `14px` (`0.875rem`) for accessibility.
+* **Headings:** Heavy weight (`font-bold` or `font-extrabold`), tight tracking (`tracking-tight`).
+
+### 3.3. Spacing & Border Radius
+
+* **Spacing System:** Strict 4px grid (Tailwind defaults: `p-4`, `m-6`, `gap-8`).
+* **Border Radius:** * Outer Containers/Cards: `rounded-2xl` or `rounded-xl`.
+* Inner Elements (Buttons/Badges): `rounded-lg` or `rounded-md`.
+* Tags/Pills: `rounded-full`.
+
+
+
+---
+
+## 4. Layout Architecture & Responsiveness
+
+The application must be fully responsive, prioritizing the mobile experience without degrading the desktop dashboard aesthetic.
+
+### 4.1. Breakpoints & Grid Behavior
+
+* **Mobile (< 640px):** * 1-column layout (`grid-cols-1`).
+* Desktop sidebars convert into a **Bottom Tab Navigation Bar** (Touch-friendly).
+* Complex data tables convert into stacked vertical cards.
+
+
+* **Tablet (640px - 1024px):**
+* 2-column Bento Grid layouts.
+* Collapsible side drawer navigation.
+
+
+* **Desktop (> 1024px):**
+* Fixed left sidebar navigation (Width: `280px`).
+* Max-width constraint on main content area (`max-w-7xl`) to maintain readability.
+* 3 to 4-column Bento Grids for data dashboards.
+
+
+
+### 4.2. Global Navigation Elements
+
+* **Header:** Glassmorphism effect (`backdrop-blur-md bg-white/70` in light mode, `bg-[#0B0E14]/70` in dark mode). Sticky top. Contains the Search Bar and Theme Toggle (Sun/Moon icon).
+* **Sidebar (Desktop):** Flat design, active states indicated by a subtle background fill (`bg-slate-100` / `bg-white/5`) and primary color text.
+
+---
+
+## 5. Component Specifications
+
+When building UI elements, AI agents must implement the following states: `default`, `hover`, `focus` (ring), `active`, and `disabled`.
+
+### 5.1. Politician Profile Card (Bento Grid Item)
+
+* **Structure:** Avatar (rounded), Name (`h2`), Current Role (`text-muted`).
+* **Integrity Gauge Chart:** A semi-circle SVG chart. The stroke color must dynamically map to the score (e.g., Green for >80, Yellow for 50-79). Use `JetBrains Mono` for the center number.
+* **Tags:** Use muted backgrounds with solid text for political parties and core competencies (e.g., `<span class="bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400">Ficha Limpa</span>`).
+
+### 5.2. Data Tables (For Proposals & Voting History)
+
+* **Style:** Borderless inner rows, separated by a 1px subtle bottom border (`border-b border-slate-200 dark:border-slate-800`).
+* **Hover State:** Entire row must highlight subtly on desktop (`hover:bg-slate-50 dark:hover:bg-white/5`).
+* **Actions:** Right-aligned standard actions (e.g., a "chevron-right" icon to view details).
+
+### 5.3. Buttons
+
+* **Primary:** Solid background (`bg-blue-600`), white text, subtle shadow (`shadow-sm`).
+* **Secondary/Outline:** Transparent background, 1px border (`border-slate-300`), text matches current theme.
+* **Hover Effects:** Slight translation upwards (`-translate-y-[1px]`) and opacity shift, transitioned smoothly (`transition-all duration-200 ease-in-out`).
+
+---
+
+## 6. Micro-Interactions & Animation
+
+Motion should be purposeful, indicating state changes or loading data, never purely decorative.
+
+* **Page Transitions:** Fade in (`opacity-0` to `opacity-100` over `300ms`).
+* **Data Loading (Skeleton Screens):** Do not use generic spinners for main content. Use animated pulse skeletons (`animate-pulse bg-slate-200 dark:bg-slate-800`) matching the shape of the incoming data (cards, text rows).
+* **Tooltips (Hints):** Crucial for explaining political/civic terminology. Must appear on `hover` (desktop) or `tap` (mobile) with a fast fade-in (`duration-150`). Use dark backgrounds for tooltips in both modes for high contrast.
+
+---
+
+## 7. UX Copywriting & Accessibility (a11y)
+
+* **Language Tone:** Neutral, educational, optimistic, and highly accessible (targeting reading level of an average citizen, avoiding "juridiquês" / legal jargon).
+* **Clarity:** Instead of "Ato de Improbidade Administrativa", use a tooltip to explain "Condenação por mau uso de dinheiro público" (Conviction for misuse of public funds).
+* **Aria Attributes:** All charts, icons, and interactive elements MUST have descriptive `aria-labels`.
+* **Touch Targets:** Minimum `44x44px` clickable area for all interactive elements (especially crucial for the mobile Tab Navigation).
+* **Focus Management:** Keyboard navigation must be fully supported with clear, high-contrast focus rings (`focus:ring-2 focus:ring-blue-500 focus:outline-none`).


### PR DESCRIPTION
## Summary

Implements mandatory Frontend Design PRD enforcement for all UI work in apps/web/ through a new web-frontend-design skill. Updates project documentation and existing skills to reference the new design compliance requirements.

## Changes

- **feat(web-frontend-design)**: New skill enforcing design tokens, typography, layout rules, component specs, and WCAG 2.1 AA accessibility requirements
- **feat(skills)**: Updated project-guardian, project-domain-rules, project-architecture, and web-testing skills to reference web-frontend-design
- **docs**: Updated CLAUDE.md, GEMINI.md, README.md, and apps/web/CLAUDE.md with design compliance requirements
- **chore**: Cleaned up CI workflow and .gitignore

## Files Changed

- 8 skill files updated (.claude/skills, .agents/skills)
- 4 project documentation files updated
- CI/CD config cleanup
- New Frontend Design PRD location documentation added

## Key Features

✅ Design token enforcement (8 semantic colors with light/dark variants)
✅ Typography rules (Inter/Plus Jakarta Sans for UI, JetBrains Mono for numbers)
✅ Layout & responsiveness (mobile-first bento grid)
✅ Component specifications (buttons, cards, tables, gauges)
✅ WCAG 2.1 AA accessibility checklist
✅ SlothUI (Figma design kit) reference integration
✅ Red flags to prevent design rationalization

## Testing

- [x] Skill structure verified
- [x] Project skill updates verified
- [x] Documentation updates verified
- [x] All commits follow conventional commit format

## Related Issues

Enforces DR-002 (Political Neutrality) and design compliance requirements from project PRD.