### PR TITLE
feat(web): RF-018 Phases 2-3-4 — Custom Fonts, Dark Mode, Home Page

### DIFF
--- a/.claude/PRPs/plans/completed/rf-018-phase2-3-4-fonts-darkmode-homepage.plan.md
+++ b/.claude/PRPs/plans/completed/rf-018-phase2-3-4-fonts-darkmode-homepage.plan.md
@@ -1,0 +1,564 @@
+# Feature: Custom Fonts + Dark Mode + Home Page (RF-018 Phases 2–4)
+
+## Summary
+
+Implement three parallel frontend capabilities that complete the visual foundation laid by Phase 1 (Design Tokens): (1) load Inter and JetBrains Mono via `next/font/google` with `display: swap` for 3G users, wiring their CSS variables into the existing `--font-sans`/`--font-mono` tokens; (2) enable user-toggleable dark mode with zero FOUC via an inline server-side `ThemeScript` component, backed by the `[data-theme]` selectors already present in `tokens.css`; (3) create the missing home page at `/` with a hero section, API-fetched top-3 politician cards, and a CTA to `/politicos`.
+
+Phases 2, 3, and 4 are independent of each other (all depend only on the completed Phase 1) and can be implemented in any order within the same session. Phase 9 (Local Full-Stack Environment) runs independently — see PRD for its separate planning.
+
+---
+
+## User Story
+
+As a Brazilian citizen visiting the platform for the first time,
+I want to see a modern, readable interface with dark mode support and a welcoming home page,
+So that I feel confident the platform is trustworthy before exploring politician data.
+
+---
+
+## Problem Statement
+
+- No home page: `/` returns 404 (confirmed: `apps/web/src/app/page.tsx` does not exist)
+- No custom fonts: `--font-sans`/`--font-mono` in `tokens.css:24–25` are static strings; `next/font` is not imported anywhere — system font renders instead of Inter
+- No dark mode toggle: `[data-theme]` selectors and `@custom-variant dark` are defined but nothing sets `data-theme` on the DOM; no ThemeScript, no ThemeToggle component
+
+---
+
+## Solution Statement
+
+**Phase 2 — Fonts:** Import `Inter` and `JetBrains_Mono` from `next/font/google` in `layout.tsx`. Apply their `.variable` CSS custom property class names to `<html>`. Update `tokens.css` to chain through those variables (`--font-sans: var(--font-inter), ...`). The existing Tailwind config already maps `font-sans` to `var(--font-sans)` — no Tailwind config change needed.
+
+**Phase 3 — Dark Mode:** Create `ThemeScript` (Server Component, inline `<script>` in `<head>`) that reads `localStorage['pah-theme']` and OS preference before first paint to set `data-theme` attribute on `<html>`. Create `ThemeToggle` (Client Component, Sun/Moon icons) that reads/writes that attribute and key. Add `suppressHydrationWarning` to `<html>`. The `@custom-variant dark` Tailwind directive and `[data-theme="dark"]` CSS vars are already present — zero CSS changes needed.
+
+**Phase 4 — Home Page:** Create `apps/web/src/app/page.tsx` as an `async` Server Component. Fetch `fetchPoliticians({ limit: 3 })` (API already sorts by `overallScore DESC`). Render hero + bento grid + CTA. Use the same Tailwind token classes as existing pages. Export `metadata` for SEO.
+
+---
+
+## Metadata
+
+| Field            | Value                                                                              |
+| ---------------- | ---------------------------------------------------------------------------------- |
+| Type             | ENHANCEMENT                                                                        |
+| Complexity       | MEDIUM                                                                             |
+| Systems Affected | `apps/web` (layout, components, app pages, styles)                                 |
+| Dependencies     | `next@^15.0.0` (already installed), `lucide-react@^0.400.0` (already installed)   |
+| Estimated Tasks  | 13 tasks across 3 phases                                                           |
+| PRD Source       | `rf-018-frontend-complete-redesign.prd.md` — Phases 2, 3, 4                       |
+
+---
+
+## UX Design
+
+### Before State
+
+```
+User visits /
+     ↓
+  404 Page Not Found
+     ↓
+  User has no entry point to the platform
+
+Header: None (no navigation, no dark mode control)
+Fonts:  System default (San Francisco / Roboto / Arial)
+Theme:  Always light (hardcoded)
+```
+
+### After State
+
+```
+User visits /
+     ↓
+  Hero: "Transparência política no Brasil"
+  Subheading + [Ver todos os políticos →] CTA
+     ↓
+  Bento grid: 3 top-scored politician cards
+     ↓
+  User clicks CTA → /politicos (existing listing)
+
+Header: ThemeToggle (Sun/Moon) in top-right of body
+Fonts:  Inter (UI) + JetBrains Mono (scores/numbers)
+Theme:  Auto-detects OS preference; user can toggle; persists to localStorage
+```
+
+### Interaction Changes
+
+| Location | Before | After | User Impact |
+|----------|--------|-------|-------------|
+| `/` | 404 error | Home page with hero + politician cards | Platform has an entry point |
+| All pages | System font renders | Inter/JetBrains Mono loaded via next/font | Brand identity, consistent render |
+| All pages | Always light mode | OS-detected + user-toggleable dark mode | Comfort for dark-mode users |
+| Layout | No toggle | Sun/Moon toggle accessible via keyboard | Can switch theme at any time |
+
+---
+
+## Mandatory Reading
+
+**CRITICAL: Implementation agent MUST read these files before starting any task:**
+
+| Priority | File | Lines | Why Read This |
+|----------|------|-------|---------------|
+| P0 | `apps/web/src/app/layout.tsx` | all | File to MODIFY — understand current structure exactly |
+| P0 | `apps/web/src/styles/tokens.css` | 22–26 | `--font-sans`/`--font-mono` lines to UPDATE |
+| P0 | `apps/web/src/styles/globals.css` | 1–12 | `@custom-variant dark` already defined — do NOT duplicate |
+| P0 | `apps/web/tailwind.config.ts` | all | `fontFamily.sans`/`fontFamily.mono` already map to CSS vars — NO CHANGE needed |
+| P1 | `apps/web/src/app/politicos/page.tsx` | all | Pattern to MIRROR for home page (async Server Component, fetchPoliticians) |
+| P1 | `apps/web/src/components/politician/politician-card.tsx` | all | Component to REUSE in home page bento grid |
+| P1 | `apps/web/src/lib/api-client.ts` | 56–69 | `fetchPoliticians` signature and return type |
+| P2 | `apps/web/src/components/filters/role-filter.tsx` | 1–10 | `'use client'` pattern for Client Components |
+
+**External Documentation:**
+
+| Source | Section | Why Needed |
+|--------|---------|------------|
+| [next/font docs](https://nextjs.org/docs/app/api-reference/components/font#font-function-arguments) | `variable` option + CSS variable usage | `Inter` variable font setup — no `weight` array needed |
+| [Next.js App Router Layout](https://nextjs.org/docs/app/api-reference/file-conventions/layout) | Root layout HTML structure | Correct placement of `<head>` child for ThemeScript |
+
+---
+
+## Patterns to Mirror
+
+**ASYNC SERVER COMPONENT (data fetching):**
+```typescript
+// SOURCE: apps/web/src/app/politicos/page.tsx:27–41
+// COPY THIS PATTERN for the home page:
+export default async function HomePage(): Promise<React.JSX.Element> {
+  // fetchPoliticians sorts by overallScore DESC — limit:3 gives top 3
+  const result = await fetchPoliticians({ limit: 3 }).catch(() => ({ data: [], cursor: null }))
+  // ...
+}
+```
+
+**TAILWIND TOKEN CLASSES (from existing components):**
+```typescript
+// SOURCE: apps/web/src/components/politician/politician-card.tsx:32
+// COPY THIS PATTERN — always use Tailwind token names, never hardcode colors:
+className="rounded-lg border border-border bg-card p-4 shadow-xs transition-shadow hover:shadow-md"
+```
+
+**CLIENT COMPONENT:**
+```typescript
+// SOURCE: apps/web/src/components/filters/role-filter.tsx:1
+// COPY THIS PATTERN for ThemeToggle:
+'use client'
+import { useState, useEffect } from 'react'
+```
+
+**FOCUS RING (a11y):**
+```typescript
+// SOURCE: apps/web/src/components/politician/politician-card.tsx:35
+// COPY THIS PATTERN for all interactive elements:
+focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2
+```
+
+**METADATA EXPORT:**
+```typescript
+// SOURCE: apps/web/src/app/politicos/page.tsx:14–22
+// COPY THIS PATTERN for home page SEO:
+export const metadata: Metadata = {
+  title: '...',
+  description: '...',
+  alternates: { canonical: 'https://autoridade-politica.com.br' },
+}
+```
+
+**SUSPENSE SKELETON:**
+```typescript
+// SOURCE: apps/web/src/app/politicos/page.tsx:54–56
+// COPY THIS PATTERN for loading states:
+<Suspense fallback={<div className="h-10 w-64 motion-safe:animate-pulse rounded-md bg-muted" />}>
+```
+
+---
+
+## Files to Change
+
+| File | Action | Justification |
+|------|--------|---------------|
+| `apps/web/src/app/layout.tsx` | UPDATE | Add font imports, `.variable` classNames on `<html>`, `suppressHydrationWarning`, `ThemeScript` in `<head>` |
+| `apps/web/src/styles/tokens.css` | UPDATE | Change `--font-sans`/`--font-mono` to use `var(--font-inter)`/`var(--font-jetbrains-mono)` |
+| `apps/web/src/components/theme-script.tsx` | CREATE | Server Component: inline `<script>` for FOUC-free dark mode |
+| `apps/web/src/components/theme-toggle.tsx` | CREATE | Client Component: Sun/Moon toggle button |
+| `apps/web/src/app/page.tsx` | CREATE | Home page: hero + top-3 politician cards + CTA |
+
+---
+
+## NOT Building (Scope Limits)
+
+- Navigation redesign (header/sidebar/mobile tab bar) — Phase 6, depends on Phase 5
+- `next-themes` installation — PRD explicitly chose custom ThemeScript (no external dep)
+- Featured politicians section using a dedicated `/featured` API endpoint — use `fetchPoliticians({ limit: 3 })` (already sorted by score DESC)
+- Advanced hero animations or illustrations — Phase 7 scope
+- Plus Jakarta Sans font — Inter is primary; Plus Jakarta Sans is fallback string only (not loaded via next/font)
+- `[data-theme]` on any element other than `<html>` — the `@custom-variant dark` variant already targets `[data-theme=dark]` attribute
+
+---
+
+## Step-by-Step Tasks
+
+Execute tasks within each phase in order. Phases 2, 3, 4 can be done in any inter-phase order.
+
+---
+
+### ── PHASE 2: CUSTOM FONTS ──
+
+### Task 2.1: UPDATE `apps/web/src/styles/tokens.css` (font variables)
+
+- **ACTION**: Modify `--font-sans` and `--font-mono` to chain through next/font CSS variables
+- **FIND**: Line with `--font-sans: 'Inter', 'Plus Jakarta Sans', sans-serif;`
+- **REPLACE WITH**: `--font-sans: var(--font-inter, 'Inter'), 'Plus Jakarta Sans', sans-serif;`
+- **FIND**: Line with `--font-mono: 'JetBrains Mono', 'Roboto Mono', monospace;`
+- **REPLACE WITH**: `--font-mono: var(--font-jetbrains-mono, 'JetBrains Mono'), 'Roboto Mono', monospace;`
+- **RATIONALE**: The `var(--font-inter, 'Inter')` pattern provides a graceful fallback if next/font's CSS variable hasn't been applied yet (e.g., in tests, SSR edge cases)
+- **GOTCHA**: Do NOT change the `[data-theme]` or `@media (prefers-color-scheme: dark)` blocks — they are correct and complete
+- **VALIDATE**: `pnpm --filter @pah/web typecheck` — tokens.css is not TypeScript but this ensures no CSS import errors
+
+### Task 2.2: UPDATE `apps/web/src/app/layout.tsx` (font integration)
+
+- **ACTION**: Import and configure `Inter` and `JetBrains_Mono` from `next/font/google`; apply `.variable` classNames to `<html>`
+- **IMPLEMENT**:
+  ```typescript
+  import { Inter, JetBrains_Mono } from 'next/font/google'
+
+  const inter = Inter({
+    subsets: ['latin', 'latin-ext'], // latin-ext for Portuguese accented chars
+    variable: '--font-inter',
+    display: 'swap',
+  })
+
+  const jetbrainsMono = JetBrains_Mono({
+    subsets: ['latin'],
+    variable: '--font-jetbrains-mono',
+    display: 'swap',
+  })
+  ```
+- **APPLY TO `<html>`**:
+  ```tsx
+  <html
+    lang="pt-BR"
+    className={`${inter.variable} ${jetbrainsMono.variable}`}
+    suppressHydrationWarning
+  >
+  ```
+- **WHY `suppressHydrationWarning`**: Required now because `data-theme` attribute will be set by ThemeScript (Task 3.1) before React hydration — avoids hydration mismatch warning. Safe to add now even before ThemeScript exists.
+- **GOTCHA**: `Inter` is a variable font — do NOT pass a `weight` array. `JetBrains_Mono` is also variable. Only `subsets` and `variable` are needed.
+- **GOTCHA**: The `.variable` className (e.g., `inter.variable`) is something like `__variable_abc123`. It registers the CSS custom property on the element. Without applying it to `<html>`, the `var(--font-inter)` in `tokens.css` will resolve to the fallback.
+- **GOTCHA**: `latin-ext` subset is needed for Portuguese characters like `ã`, `ç`, `ê`, `ó` — without it some accented characters fall back to system font
+- **DO NOT** add `font-sans` to `<html>` — it's already on `<body>` (line 33: `className="min-h-screen bg-background font-sans antialiased"`)
+- **DO NOT** change PlausibleProvider placement — it wraps `<body>`, not `<html>`
+- **VALIDATE**: `pnpm --filter @pah/web build` — confirms font variables load; Chrome DevTools → Network tab shows Inter font file loaded
+
+---
+
+### ── PHASE 3: DARK MODE ──
+
+### Task 3.1: CREATE `apps/web/src/components/theme-script.tsx`
+
+- **ACTION**: Create Server Component that renders an inline `<script>` tag for FOUC prevention
+- **IMPLEMENT**:
+  ```typescript
+  // apps/web/src/components/theme-script.tsx
+  // Server Component — no 'use client' directive
+  export function ThemeScript(): React.JSX.Element {
+    const script = `
+      (function() {
+        try {
+          var stored = localStorage.getItem('pah-theme');
+          var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+          var theme = stored === 'dark' || stored === 'light'
+            ? stored
+            : (prefersDark ? 'dark' : 'light');
+          document.documentElement.setAttribute('data-theme', theme);
+        } catch (e) {}
+      })();
+    `.replace(/</g, '\\u003c');
+
+    return <script dangerouslySetInnerHTML={{ __html: script }} />;
+  }
+  ```
+- **EXPLICIT RETURN TYPE**: `React.JSX.Element` (project convention)
+- **GOTCHA**: The `.replace(/</g, '\\u003c')` escapes `<` to prevent HTML injection — required when using `dangerouslySetInnerHTML` with user-influenced content. Keep it.
+- **GOTCHA**: The `try/catch` prevents crashes in environments without `localStorage` (Safari private mode, SSR edge cases)
+- **GOTCHA**: `stored === 'dark' || stored === 'light'` validation ensures arbitrary localStorage values are ignored (avoids setting `data-theme="null"` or other invalid values)
+- **WHY SERVER COMPONENT**: No `'use client'` — this renders as a pure HTML `<script>` string on the server. Adding `'use client'` would make it a hydrated React component with unnecessary JS overhead.
+- **VALIDATE**: `pnpm --filter @pah/web typecheck`
+
+### Task 3.2: CREATE `apps/web/src/components/theme-toggle.tsx`
+
+- **ACTION**: Create Client Component for Sun/Moon toggle button
+- **IMPLEMENT**:
+  ```typescript
+  'use client'
+
+  import { useEffect, useState } from 'react'
+  import { Sun, Moon } from 'lucide-react'
+
+  const STORAGE_KEY = 'pah-theme'
+
+  export function ThemeToggle(): React.JSX.Element {
+    const [theme, setTheme] = useState<'light' | 'dark'>('light')
+    const [mounted, setMounted] = useState(false)
+
+    useEffect(() => {
+      setMounted(true)
+      const stored = localStorage.getItem(STORAGE_KEY)
+      const current = document.documentElement.getAttribute('data-theme')
+      setTheme((stored ?? current ?? 'light') as 'light' | 'dark')
+    }, [])
+
+    const toggle = (): void => {
+      const next = theme === 'light' ? 'dark' : 'light'
+      setTheme(next)
+      document.documentElement.setAttribute('data-theme', next)
+      localStorage.setItem(STORAGE_KEY, next)
+    }
+
+    // Render a placeholder until mounted to avoid hydration mismatch
+    if (!mounted) {
+      return <div className="h-9 w-9" aria-hidden="true" />
+    }
+
+    return (
+      <button
+        type="button"
+        onClick={toggle}
+        aria-label={theme === 'light' ? 'Ativar modo escuro' : 'Ativar modo claro'}
+        className="flex h-9 w-9 items-center justify-center rounded-md border border-border text-foreground transition-colors hover:bg-muted focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+      >
+        {theme === 'light' ? (
+          <Moon size={16} aria-hidden="true" />
+        ) : (
+          <Sun size={16} aria-hidden="true" />
+        )}
+      </button>
+    )
+  }
+  ```
+- **MOUNTED GUARD**: Reads DOM state only after mount to prevent SSR/client mismatch. The placeholder `<div>` matches the button's dimensions to prevent layout shift.
+- **GOTCHA**: Do NOT render `Sun`/`Moon` based on `useState` initial value during SSR — always show nothing (or stable placeholder) until `useEffect` fires
+- **STORAGE_KEY**: Use `'pah-theme'` (matching ThemeScript's `localStorage.getItem('pah-theme')`)
+- **lucide-react**: Already installed at `^0.400.0` — `Sun` and `Moon` are available
+- **DR-002**: Button text is neutral ("Ativar modo escuro/claro") — no party associations
+- **VALIDATE**: `pnpm --filter @pah/web typecheck`
+
+### Task 3.3: UPDATE `apps/web/src/app/layout.tsx` (ThemeScript integration)
+
+- **ACTION**: Add `<head>` with `ThemeScript` to the root layout. Add `ThemeToggle` to the body.
+- **IMPLEMENT** — add to layout after font changes from Task 2.2:
+  ```tsx
+  import { ThemeScript } from '../components/theme-script'
+  import { ThemeToggle } from '../components/theme-toggle'
+
+  export default function RootLayout({ children }: { children: React.ReactNode }): React.JSX.Element {
+    return (
+      <html
+        lang="pt-BR"
+        className={`${inter.variable} ${jetbrainsMono.variable}`}
+        suppressHydrationWarning
+      >
+        <head>
+          <ThemeScript />
+        </head>
+        <PlausibleProvider ...>
+          <body className="min-h-screen bg-background font-sans antialiased">
+            <a href="#main-content" className="sr-only focus:not-sr-only ...">
+              Ir para o conteúdo principal
+            </a>
+            <div className="fixed right-4 top-4 z-50">
+              <ThemeToggle />
+            </div>
+            {children}
+          </body>
+        </PlausibleProvider>
+      </html>
+    )
+  }
+  ```
+- **ThemeToggle placement**: `fixed right-4 top-4 z-50` — floating top-right corner. Phase 6 (Navigation Redesign) will integrate it into the header properly.
+- **GOTCHA**: Next.js App Router automatically deduplicates `<head>` — adding `<head>` with `ThemeScript` is valid and will be merged with Next.js-managed head tags
+- **GOTCHA**: `suppressHydrationWarning` on `<html>` silences the warning from `data-theme` being set by ThemeScript before React hydration. This is intentional and safe.
+- **VALIDATE**: 
+  - `pnpm --filter @pah/web build`
+  - Hard refresh in browser → observe no flash of light mode before dark mode applies
+  - Toggle works and persists across page refreshes
+
+---
+
+### ── PHASE 4: HOME PAGE ──
+
+### Task 4.1: CREATE `apps/web/src/app/page.tsx`
+
+- **ACTION**: Create home page as `async` Server Component with hero + featured politicians + CTA
+- **IMPLEMENT**:
+  ```typescript
+  // apps/web/src/app/page.tsx
+  import { Suspense } from 'react'
+  import type { Metadata } from 'next'
+  import Link from 'next/link'
+  import { fetchPoliticians } from '../lib/api-client'
+  import { PoliticianCard } from '../components/politician/politician-card'
+
+  export const revalidate = 3600  // ISR: revalidate every hour
+
+  export const metadata: Metadata = {
+    title: 'Autoridade Política — Transparência Política no Brasil',
+    description:
+      'Explore dados públicos de integridade de deputados federais e senadores brasileiros.',
+    alternates: { canonical: 'https://autoridade-politica.com.br' },
+    openGraph: {
+      title: 'Autoridade Política — Transparência Política no Brasil',
+      description: 'Explore dados públicos de integridade de deputados e senadores.',
+      url: 'https://autoridade-politica.com.br',
+    },
+  }
+
+  export default async function HomePage(): Promise<React.JSX.Element> {
+    // API sorts by overallScore DESC — limit:3 returns the top 3 politicians
+    const result = await fetchPoliticians({ limit: 3 }).catch(() => ({ data: [], cursor: null }))
+
+    return (
+      <main id="main-content" tabIndex={-1} className="focus:outline-none">
+        {/* Hero */}
+        <section className="container mx-auto px-4 py-16 text-center">
+          <h1 className="mb-4 text-4xl font-bold text-foreground sm:text-5xl">
+            Transparência política no Brasil
+          </h1>
+          <p className="mx-auto mb-8 max-w-xl text-lg text-muted-foreground">
+            Dados públicos de integridade de deputados federais e senadores, cruzados de 6 fontes
+            oficiais do governo.
+          </p>
+          <Link
+            href="/politicos"
+            className="inline-flex items-center rounded-xl bg-primary px-6 py-3 font-semibold text-primary-foreground transition-all duration-200 hover:-translate-y-[1px] hover:shadow-md focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+          >
+            Ver todos os políticos →
+          </Link>
+        </section>
+
+        {/* Featured politicians — bento grid */}
+        {result.data.length > 0 && (
+          <section
+            className="container mx-auto px-4 pb-16"
+            aria-labelledby="featured-heading"
+          >
+            <h2
+              id="featured-heading"
+              className="mb-6 text-xl font-semibold text-foreground"
+            >
+              Políticos em destaque
+            </h2>
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {result.data.map((politician, index) => (
+                <PoliticianCard
+                  key={politician.id}
+                  politician={politician}
+                  isAboveFold={true}
+                />
+              ))}
+            </div>
+          </section>
+        )}
+      </main>
+    )
+  }
+  ```
+- **IMPORTANT**: The `.catch(() => ({ data: [], cursor: null }))` fallback ensures the page builds even when the API is unavailable (e.g., during `pnpm build` on CI with no API running)
+- **isAboveFold={true}**: All 3 featured cards are above the fold — `priority` loading for all photos
+- **`revalidate = 3600`**: Matches politician profile page ISR cadence; featured list updates hourly
+- **DR-002**: `aria-labelledby="featured-heading"` links section to neutral heading. No qualitative labels ("top", "best"). Section heading: "Políticos em destaque" (neutral)
+- **GOTCHA**: Do NOT use `sort=score_desc` query param — the API already sorts by `overallScore DESC` by default (confirmed in `politician.repository.ts`)
+- **GOTCHA**: `metadata.title` at page level overrides the `layout.tsx` metadata template. Home page should use the full title, not the template pattern.
+- **VALIDATE**: 
+  - `pnpm --filter @pah/web build`
+  - `curl http://localhost:3000` returns 200
+  - Page passes aXe-core (no a11y violations)
+  - CTA links to `/politicos`
+  - Responsive on 375px / 768px / 1920px
+
+---
+
+## Testing Strategy
+
+### Validation Gates (per PRD)
+
+After completing ALL tasks:
+
+```bash
+# 1. Type check
+pnpm --filter @pah/web typecheck
+
+# 2. Lint
+pnpm --filter @pah/web lint
+
+# 3. Unit tests
+pnpm --filter @pah/web test
+
+# 4. Full build (MANDATORY)
+pnpm build
+
+# 5. Vercel build (MANDATORY — final gate)
+vercel build --yes
+
+# 6. E2E: accessibility (requires running dev server)
+pnpm --filter @pah/web test:e2e -- --grep "accessibility"
+```
+
+### Manual Checks
+
+| Check | How | Expected |
+|-------|-----|----------|
+| Inter font renders | Chrome DevTools → Network → filter Fonts | `inter-*.woff2` loaded |
+| JetBrains Mono on scores | DevTools → Elements → computed font | `JetBrains Mono` for `.font-mono` elements |
+| Dark mode toggle | Click Sun/Moon → refresh | Theme persists; no FOUC |
+| OS preference | Set OS to dark → hard refresh | Dark mode applied without toggle |
+| Home page 200 | `curl http://localhost:3000` | 200 OK |
+| CTA link | Click "Ver todos" | Navigates to `/politicos` |
+| Mobile layout | DevTools → 375px | Single-column grid, hero readable |
+| A11y | Run `checkA11y` in accessibility.spec.ts | 0 violations on `/` |
+
+### Unit Tests to Write
+
+| Test File | Test Cases | Validates |
+|-----------|-----------|-----------|
+| `apps/web/src/components/theme-toggle.test.tsx` | renders placeholder before mount; toggles theme on click; writes to localStorage | ThemeToggle logic |
+| `apps/web/src/app/page.test.tsx` | renders hero h1; renders CTA link; gracefully renders empty state if fetchPoliticians throws | Home page render |
+
+---
+
+## Edge Cases
+
+- **API unavailable during build**: `fetchPoliticians({ limit: 3 }).catch(...)` fallback in page.tsx returns `{ data: [], cursor: null }` — home page builds with no politician cards shown (hero only)
+- **localStorage unavailable** (Safari private mode, SSR): ThemeScript wraps in `try/catch` — dark mode falls back to OS preference detection via `matchMedia`
+- **Hydration mismatch**: `suppressHydrationWarning` on `<html>` + mounted-guard in ThemeToggle prevents React hydration errors
+- **Portuguese characters in Inter**: `latin-ext` subset covers `ã`, `ç`, `ê`, `ó`, `ú` etc. — required for politician names and UI text
+- **No featured politicians in DB**: Section is conditionally rendered with `result.data.length > 0` — hero still shows
+- **ThemeToggle placeholder CLS**: The `<div className="h-9 w-9" />` placeholder matches button dimensions exactly — zero layout shift on hydration
+
+---
+
+## Known Risks
+
+| Risk | Mitigation |
+|------|-----------|
+| Font CLS on 3G | `display: 'swap'` shows system font during load → transitions to Inter. CLS < 0.1 expected. |
+| FOUC on `data-theme` | ThemeScript in `<head>` fires before first paint — FOUC eliminated |
+| `pnpm build` fails if API down | `.catch()` fallback in home page; `generateStaticParams` already uses same pattern in profile page |
+| `lucide-react` icon tree-shaking | Next.js + Turbopack handles it; only `Sun` and `Moon` imported — no bundle concern |
+
+---
+
+## References
+
+- PRD: `rf-018-frontend-complete-redesign.prd.md` (Phases 2, 3, 4)
+- Design tokens: `apps/web/src/styles/tokens.css`
+- Tailwind custom variant: `apps/web/src/styles/globals.css:9`
+- API client: `apps/web/src/lib/api-client.ts:56–69`
+- Existing listing page (pattern): `apps/web/src/app/politicos/page.tsx`
+- Playwright config: `apps/web/playwright.config.ts`
+- A11y spec (extend for home page): `apps/web/e2e/accessibility.spec.ts`
+
+---
+
+*Generated: 2026-03-16*
+*PRD: rf-018-frontend-complete-redesign.prd.md — Phases 2 (Custom Fonts), 3 (Dark Mode), 4 (Home Page)*
+*Status: Ready for implementation*
+*Next step: Run `prp-implement .claude/PRPs/plans/rf-018-phase2-3-4-fonts-darkmode-homepage.plan.md`*

--- a/.claude/PRPs/prds/rf-018-frontend-complete-redesign.prd.md
+++ b/.claude/PRPs/prds/rf-018-frontend-complete-redesign.prd.md
@@ -561,7 +561,7 @@ Phase 1 (foundation) → Phases 2, 3, 4, 9 in parallel
   - ✅ Tailwind v4 full migration — installed `@tailwindcss/postcss`, fixed breaking changes (shadow-sm→shadow-xs)
 - **Validation**: ✅ `pnpm typecheck` (5 packages), ✅ `pnpm lint`, ✅ `pnpm build`, ✅ `vercel build`
 
-### Phase 2: Custom Fonts
+### Phase 2: Custom Fonts ✅ complete — PR #39
 - **Goal**: Load Inter and JetBrains Mono via `next/font` with `display: swap` for 3G users
 - **Scope**:
   - Import fonts in `apps/web/src/app/layout.tsx` using `next/font/google`
@@ -570,7 +570,7 @@ Phase 1 (foundation) → Phases 2, 3, 4, 9 in parallel
   - Verify no Cumulative Layout Shift (CLS > 0) via Lighthouse
 - **Mandatory gates**: Chrome DevTools shows Inter rendering; no CLS in Lighthouse; run `docs:update-docs`
 
-### Phase 3: Dark Mode
+### Phase 3: Dark Mode ✅ complete — PR #39
 - **Goal**: System preference auto-applies; user can toggle; no FOUC
 - **Scope**:
   - Create `ThemeScript` server component (inline script for FOUC prevention in `<head>`)
@@ -579,7 +579,7 @@ Phase 1 (foundation) → Phases 2, 3, 4, 9 in parallel
   - Add `ThemeScript` before all other children in root layout
 - **Mandatory gates**: Toggle switches modes; OS preference detected on first load; no FOUC on hard refresh; run `docs:update-docs`
 
-### Phase 4: Home Page
+### Phase 4: Home Page ✅ complete — PR #39
 - **Goal**: `/` loads with hero, API-fetched featured politicians, CTA button
 - **Scope**:
   - Create `apps/web/src/app/page.tsx`

--- a/.claude/PRPs/reports/rf-018-phase2-3-4-fonts-darkmode-homepage-report.md
+++ b/.claude/PRPs/reports/rf-018-phase2-3-4-fonts-darkmode-homepage-report.md
@@ -1,0 +1,89 @@
+# Implementation Report
+
+**Plan**: `.claude/PRPs/plans/rf-018-phase2-3-4-fonts-darkmode-homepage.plan.md`
+**Branch**: `feat/rf-018-phase2-3-4-fonts-darkmode-homepage`
+**Date**: 2026-03-16
+**Status**: COMPLETE
+
+---
+
+## Summary
+
+Implemented three parallel frontend capabilities completing the visual foundation for RF-018:
+
+1. **Phase 2 — Custom Fonts**: `Inter` and `JetBrains_Mono` loaded via `next/font/google` with `display: swap`, CSS variables `--font-inter`/`--font-jetbrains-mono` wired into `tokens.css` via `var()` fallback pattern. Latin-ext subset included for Portuguese characters.
+
+2. **Phase 3 — Dark Mode**: Zero-FOUC `ThemeScript` Server Component inlines a script in `<head>` to read `localStorage['pah-theme']` and OS preference before first paint. `ThemeToggle` Client Component provides Sun/Moon toggle with mounted-guard to prevent hydration mismatch. `suppressHydrationWarning` added to `<html>`.
+
+3. **Phase 4 — Home Page**: `/` page created as async Server Component with hero section (heading + description + CTA), bento grid of top-3 politician cards (via `fetchPoliticians({ limit: 3 })`), ISR revalidation at 3600s, full SEO metadata and OpenGraph tags.
+
+---
+
+## Assessment vs Reality
+
+| Metric | Predicted | Actual | Reasoning |
+|--------|-----------|--------|-----------|
+| Complexity | MEDIUM | MEDIUM | Matched — all files existed or were created as specified |
+| Confidence | HIGH | HIGH | Root cause was correct; patterns from existing pages transferred cleanly |
+
+**Deviations from plan:**
+
+- `theme-toggle.tsx`: replaced `as 'light' | 'dark'` type assertion with `value === 'dark' ? 'dark' : 'light'` ternary to comply with `no-unsafe-assignment` lint rule (avoids `as` assertion per project TypeScript rules)
+- Unit tests: `localStorage.clear()` unavailable in jsdom environment; used `vi.stubGlobal('localStorage', createLocalStorageMock())` with a custom in-memory implementation
+
+---
+
+## Tasks Completed
+
+| # | Task | File | Status |
+|---|------|------|--------|
+| 2.1 | UPDATE font CSS variables | `apps/web/src/styles/tokens.css` | ✅ |
+| 2.2 | UPDATE layout with Inter + JetBrains Mono | `apps/web/src/app/layout.tsx` | ✅ |
+| 3.1 | CREATE ThemeScript Server Component | `apps/web/src/components/theme-script.tsx` | ✅ |
+| 3.2 | CREATE ThemeToggle Client Component | `apps/web/src/components/theme-toggle.tsx` | ✅ |
+| 3.3 | UPDATE layout with ThemeScript + ThemeToggle | `apps/web/src/app/layout.tsx` | ✅ |
+| 4.1 | CREATE home page | `apps/web/src/app/page.tsx` | ✅ |
+| T1 | WRITE ThemeToggle unit tests | `apps/web/src/components/theme-toggle.test.tsx` | ✅ |
+| T2 | WRITE HomePage unit tests | `apps/web/src/app/page.test.tsx` | ✅ |
+
+---
+
+## Validation Results
+
+| Check | Result | Details |
+|-------|--------|---------|
+| Type check | ✅ | `pnpm --filter @pah/web typecheck` — 0 errors |
+| Lint | ✅ | `pnpm --filter @pah/web lint` — 0 errors |
+| Unit tests | ✅ | 70 passed (13 test files), 0 failed |
+| Build | ✅ | `pnpm build` — all 9 static pages generated; `/` shows as `○ Static` |
+
+---
+
+## Files Changed
+
+| File | Action | Notes |
+|------|--------|-------|
+| `apps/web/src/styles/tokens.css` | UPDATE | `--font-sans`/`--font-mono` now use `var(--font-inter)`/`var(--font-jetbrains-mono)` fallback pattern |
+| `apps/web/src/app/layout.tsx` | UPDATE | Inter + JetBrains_Mono fonts, ThemeScript in `<head>`, ThemeToggle in fixed top-right, `suppressHydrationWarning` |
+| `apps/web/src/components/theme-script.tsx` | CREATE | Server Component; IIFE sets `data-theme` from localStorage/OS pref before first paint |
+| `apps/web/src/components/theme-toggle.tsx` | CREATE | Client Component; Sun/Moon toggle; mounted guard prevents SSR mismatch |
+| `apps/web/src/app/page.tsx` | CREATE | Hero + bento grid + CTA; ISR 3600s; full SEO metadata |
+| `apps/web/src/components/theme-toggle.test.tsx` | CREATE | 7 tests: toggle behavior, localStorage writes, data-theme attribute |
+| `apps/web/src/app/page.test.tsx` | CREATE | 5 tests: hero heading, CTA link, politician cards, error fallback, empty state |
+
+---
+
+## Tests Written
+
+| Test File | Test Cases |
+|-----------|-----------|
+| `apps/web/src/components/theme-toggle.test.tsx` | renders button after hydration; defaults to light mode; reads dark from localStorage; toggles light→dark; writes to localStorage; sets data-theme; toggles dark→light |
+| `apps/web/src/app/page.test.tsx` | renders hero heading; renders CTA to /politicos; renders politician cards; graceful empty on API throw; no featured section when empty |
+
+---
+
+## Next Steps
+
+- [ ] Review and approve PR
+- [ ] Merge to main
+- [ ] Continue with RF-018 Phase 5: Component Refinement

--- a/apps/web/e2e/accessibility.spec.ts
+++ b/apps/web/e2e/accessibility.spec.ts
@@ -18,6 +18,11 @@ async function checkA11y(page: Page, testInfo: TestInfo): Promise<void> {
 }
 
 test.describe('Accessibility — WCAG 2.1 AA', () => {
+  test('home page', async ({ page }, testInfo) => {
+    await page.goto('/')
+    await checkA11y(page, testInfo)
+  })
+
   test('listagem de políticos', async ({ page }, testInfo) => {
     await page.goto('/politicos')
     await checkA11y(page, testInfo)

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,6 +1,21 @@
 import type { Metadata } from 'next'
+import { Inter, JetBrains_Mono } from 'next/font/google'
 import PlausibleProvider from 'next-plausible'
+import { ThemeScript } from '../components/theme-script'
+import { ThemeToggle } from '../components/theme-toggle'
 import '../styles/globals.css'
+
+const inter = Inter({
+  subsets: ['latin', 'latin-ext'],
+  variable: '--font-inter',
+  display: 'swap',
+})
+
+const jetbrainsMono = JetBrains_Mono({
+  subsets: ['latin'],
+  variable: '--font-jetbrains-mono',
+  display: 'swap',
+})
 
 export const metadata: Metadata = {
   metadataBase: new URL(
@@ -24,7 +39,14 @@ export default function RootLayout({
   children: React.ReactNode
 }): React.JSX.Element {
   return (
-    <html lang="pt-BR">
+    <html
+      lang="pt-BR"
+      className={`${inter.variable} ${jetbrainsMono.variable}`}
+      suppressHydrationWarning
+    >
+      <head>
+        <ThemeScript />
+      </head>
       <PlausibleProvider
         domain={process.env['NEXT_PUBLIC_PLAUSIBLE_DOMAIN'] ?? 'autoridade-politica.com.br'}
         enabled={process.env['NEXT_PUBLIC_PLAUSIBLE_ENABLED'] === 'true'}
@@ -37,6 +59,9 @@ export default function RootLayout({
           >
             Ir para o conteúdo principal
           </a>
+          <div className="fixed right-4 top-4 z-50">
+            <ThemeToggle />
+          </div>
           {children}
         </body>
       </PlausibleProvider>

--- a/apps/web/src/app/page.test.tsx
+++ b/apps/web/src/app/page.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import type { PoliticianCard } from '@pah/shared'
+import type { Role } from '@pah/shared'
+import { fetchPoliticians } from '../lib/api-client'
+import HomePage from './page'
+
+vi.mock('../lib/api-client', () => ({
+  fetchPoliticians: vi.fn(),
+}))
+
+const mockPolitician: PoliticianCard = {
+  id: '1',
+  slug: 'joao-silva-sp',
+  name: 'João Silva',
+  party: 'PL',
+  state: 'SP',
+  role: 'deputado' as Role,
+  photoUrl: null,
+  tenureStartDate: null,
+  overallScore: 85,
+}
+
+describe('HomePage', () => {
+  it('renders hero heading', async () => {
+    vi.mocked(fetchPoliticians).mockResolvedValueOnce({ data: [], cursor: null })
+    render(await HomePage())
+    expect(
+      screen.getByRole('heading', { level: 1, name: /transparência política no brasil/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('renders CTA link pointing to /politicos', async () => {
+    vi.mocked(fetchPoliticians).mockResolvedValueOnce({ data: [], cursor: null })
+    render(await HomePage())
+    expect(screen.getByRole('link', { name: /ver todos os políticos/i })).toHaveAttribute(
+      'href',
+      '/politicos',
+    )
+  })
+
+  it('renders featured politician cards when data is available', async () => {
+    vi.mocked(fetchPoliticians).mockResolvedValueOnce({
+      data: [mockPolitician],
+      cursor: null,
+    })
+    render(await HomePage())
+    expect(screen.getByText('Políticos em destaque')).toBeInTheDocument()
+    expect(screen.getByText('João Silva')).toBeInTheDocument()
+  })
+
+  it('renders hero without featured section when fetchPoliticians throws', async () => {
+    vi.mocked(fetchPoliticians).mockRejectedValueOnce(new Error('API unavailable'))
+    render(await HomePage())
+    expect(
+      screen.getByRole('heading', { level: 1, name: /transparência política no brasil/i }),
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/políticos em destaque/i)).not.toBeInTheDocument()
+  })
+
+  it('renders hero without featured section when API returns empty data', async () => {
+    vi.mocked(fetchPoliticians).mockResolvedValueOnce({ data: [], cursor: null })
+    render(await HomePage())
+    expect(screen.queryByText(/políticos em destaque/i)).not.toBeInTheDocument()
+  })
+})

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,0 +1,69 @@
+// ISR: revalidate every 1 hour (same cadence as politician listing)
+export const revalidate = 3600
+
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { fetchPoliticians } from '../lib/api-client'
+import { PoliticianCard } from '../components/politician/politician-card'
+
+export const metadata: Metadata = {
+  title: 'Autoridade Política — Transparência Política no Brasil',
+  description:
+    'Explore dados públicos de integridade de deputados federais e senadores brasileiros.',
+  alternates: { canonical: 'https://autoridade-politica.com.br' },
+  openGraph: {
+    title: 'Autoridade Política — Transparência Política no Brasil',
+    description: 'Explore dados públicos de integridade de deputados e senadores.',
+    url: 'https://autoridade-politica.com.br',
+  },
+}
+
+export default async function HomePage(): Promise<React.JSX.Element> {
+  // API sorts by overallScore DESC — limit:3 returns the top 3 politicians
+  const result = await fetchPoliticians({ limit: 3 }).catch(() => ({ data: [], cursor: null }))
+
+  return (
+    <main id="main-content" tabIndex={-1} className="focus:outline-none">
+      {/* Hero */}
+      <section className="container mx-auto px-4 py-16 text-center">
+        <h1 className="mb-4 text-4xl font-bold text-foreground sm:text-5xl">
+          Transparência política no Brasil
+        </h1>
+        <p className="mx-auto mb-8 max-w-xl text-lg text-muted-foreground">
+          Dados públicos de integridade de deputados federais e senadores, cruzados de 6 fontes
+          oficiais do governo.
+        </p>
+        <Link
+          href="/politicos"
+          className="inline-flex items-center rounded-xl bg-primary px-6 py-3 font-semibold text-primary-foreground transition-all duration-200 hover:-translate-y-[1px] hover:shadow-md focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+        >
+          Ver todos os políticos →
+        </Link>
+      </section>
+
+      {/* Featured politicians — bento grid */}
+      {result.data.length > 0 && (
+        <section
+          className="container mx-auto px-4 pb-16"
+          aria-labelledby="featured-heading"
+        >
+          <h2
+            id="featured-heading"
+            className="mb-6 text-xl font-semibold text-foreground"
+          >
+            Políticos em destaque
+          </h2>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {result.data.map((politician) => (
+              <PoliticianCard
+                key={politician.id}
+                politician={politician}
+                isAboveFold={true}
+              />
+            ))}
+          </div>
+        </section>
+      )}
+    </main>
+  )
+}

--- a/apps/web/src/components/theme-script.tsx
+++ b/apps/web/src/components/theme-script.tsx
@@ -1,0 +1,17 @@
+// Server Component — no 'use client' directive
+export function ThemeScript(): React.JSX.Element {
+  const script = `
+    (function() {
+      try {
+        var stored = localStorage.getItem('pah-theme');
+        var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        var theme = stored === 'dark' || stored === 'light'
+          ? stored
+          : (prefersDark ? 'dark' : 'light');
+        document.documentElement.setAttribute('data-theme', theme);
+      } catch (e) {}
+    })();
+  `.replace(/</g, '\\u003c')
+
+  return <script dangerouslySetInnerHTML={{ __html: script }} />
+}

--- a/apps/web/src/components/theme-toggle.test.tsx
+++ b/apps/web/src/components/theme-toggle.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { ThemeToggle } from './theme-toggle'
+
+// Provide a standard in-memory localStorage since the jsdom environment
+// uses a custom storage that doesn't expose the standard Storage API
+const createLocalStorageMock = (): Storage => {
+  const store: Record<string, string> = {}
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => {
+      store[key] = value
+    },
+    removeItem: (key: string) => {
+      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+      delete store[key]
+    },
+    clear: () => {
+      for (const key of Object.keys(store)) {
+        // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+        delete store[key]
+      }
+    },
+    key: (index: number) => Object.keys(store)[index] ?? null,
+    get length() {
+      return Object.keys(store).length
+    },
+  }
+}
+
+describe('ThemeToggle', () => {
+  beforeEach(() => {
+    vi.stubGlobal('localStorage', createLocalStorageMock())
+    document.documentElement.removeAttribute('data-theme')
+  })
+
+  it('renders toggle button after hydration', () => {
+    render(<ThemeToggle />)
+    expect(screen.getByRole('button')).toBeInTheDocument()
+  })
+
+  it('defaults to light mode (shows moon icon) when no stored preference', () => {
+    render(<ThemeToggle />)
+    expect(screen.getByRole('button', { name: 'Ativar modo escuro' })).toBeInTheDocument()
+  })
+
+  it('reads stored dark theme from localStorage on mount', () => {
+    localStorage.setItem('pah-theme', 'dark')
+    render(<ThemeToggle />)
+    expect(screen.getByRole('button', { name: 'Ativar modo claro' })).toBeInTheDocument()
+  })
+
+  it('toggles from light to dark on click', () => {
+    render(<ThemeToggle />)
+    fireEvent.click(screen.getByRole('button', { name: 'Ativar modo escuro' }))
+    expect(screen.getByRole('button', { name: 'Ativar modo claro' })).toBeInTheDocument()
+  })
+
+  it('writes new theme to localStorage on toggle', () => {
+    render(<ThemeToggle />)
+    fireEvent.click(screen.getByRole('button'))
+    expect(localStorage.getItem('pah-theme')).toBe('dark')
+  })
+
+  it('sets data-theme attribute on documentElement when toggled', () => {
+    render(<ThemeToggle />)
+    fireEvent.click(screen.getByRole('button'))
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark')
+  })
+
+  it('toggles from dark back to light on second click', () => {
+    localStorage.setItem('pah-theme', 'dark')
+    render(<ThemeToggle />)
+    fireEvent.click(screen.getByRole('button', { name: 'Ativar modo claro' }))
+    expect(localStorage.getItem('pah-theme')).toBe('light')
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light')
+  })
+})

--- a/apps/web/src/components/theme-toggle.tsx
+++ b/apps/web/src/components/theme-toggle.tsx
@@ -1,0 +1,44 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Moon, Sun } from 'lucide-react'
+
+const STORAGE_KEY = 'pah-theme'
+
+export function ThemeToggle(): React.JSX.Element {
+  const [theme, setTheme] = useState<'light' | 'dark'>('light')
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+    const stored = localStorage.getItem(STORAGE_KEY)
+    const current = document.documentElement.getAttribute('data-theme')
+    setTheme((stored ?? current ?? 'light') as 'light' | 'dark')
+  }, [])
+
+  const toggle = (): void => {
+    const next = theme === 'light' ? 'dark' : 'light'
+    setTheme(next)
+    document.documentElement.setAttribute('data-theme', next)
+    localStorage.setItem(STORAGE_KEY, next)
+  }
+
+  if (!mounted) {
+    return <div className="h-9 w-9" aria-hidden="true" />
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      aria-label={theme === 'light' ? 'Ativar modo escuro' : 'Ativar modo claro'}
+      className="flex h-9 w-9 items-center justify-center rounded-md border border-border text-foreground transition-colors hover:bg-muted focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+    >
+      {theme === 'light' ? (
+        <Moon size={16} aria-hidden="true" />
+      ) : (
+        <Sun size={16} aria-hidden="true" />
+      )}
+    </button>
+  )
+}

--- a/apps/web/src/components/theme-toggle.tsx
+++ b/apps/web/src/components/theme-toggle.tsx
@@ -13,7 +13,8 @@ export function ThemeToggle(): React.JSX.Element {
     setMounted(true)
     const stored = localStorage.getItem(STORAGE_KEY)
     const current = document.documentElement.getAttribute('data-theme')
-    setTheme((stored ?? current ?? 'light') as 'light' | 'dark')
+    const value = stored ?? current ?? 'light'
+    setTheme(value === 'dark' ? 'dark' : 'light')
   }, [])
 
   const toggle = (): void => {

--- a/apps/web/src/styles/tokens.css
+++ b/apps/web/src/styles/tokens.css
@@ -21,8 +21,8 @@
   --color-ring: #1D4ED8;
 
   /* Typography Scales */
-  --font-sans: 'Inter', 'Plus Jakarta Sans', sans-serif;
-  --font-mono: 'JetBrains Mono', 'Roboto Mono', monospace;
+  --font-sans: var(--font-inter, 'Inter'), 'Plus Jakarta Sans', sans-serif;
+  --font-mono: var(--font-jetbrains-mono, 'JetBrains Mono'), 'Roboto Mono', monospace;
 
   /* Spacing */
   --space-1: 0.25rem; /* 4px */


### PR DESCRIPTION
## Summary

Implements RF-018 Phases 2, 3, and 4 on top of the already-merged Phase 1 (design tokens, PR #37).

## Changes

### Phase 2 — Custom Fonts
- `tokens.css`: Chain `--font-sans`/`--font-mono` through `var(--font-inter, ...)` / `var(--font-jetbrains-mono, ...)` for graceful fallback
- `layout.tsx`: Load `Inter` + `JetBrains_Mono` via `next/font/google` (variable fonts, `latin-ext` subset for Portuguese), inject `.variable` classNames on `<html>`

### Phase 3 — Dark Mode (no external deps)
- `theme-script.tsx`: FOUC-prevention Server Component — inline `<script>` reads `localStorage['pah-theme']` + `matchMedia` before first paint, sets `data-theme` on `<html>`
- `theme-toggle.tsx`: Client Component — Sun/Moon toggle (`lucide-react`), mounted guard returns 9×9 placeholder before hydration to prevent CLS
- `layout.tsx`: `<head><ThemeScript/></head>`, `suppressHydrationWarning`, fixed-position ThemeToggle (top-right)

### Phase 4 — Home Page
- `page.tsx`: Async Server Component, ISR revalidate, hero section, top-3 politician cards via `fetchPoliticians({limit:3})` with `.catch()` fallback, CTA to `/politicos`; fixes previous 404 at `/`

### E2E
- Added WCAG 2.1 AA accessibility test for `/` (home page route)

## Validation
- ✅ `pnpm --filter @pah/web typecheck` — 0 errors
- ✅ `pnpm --filter @pah/web lint` — 0 warnings
- ✅ `pnpm build` — all 5 packages built, 9 routes generated
- ✅ `vercel build --yes` — completed successfully

## Domain Rules
- **DR-002**: No party colors; neutral palette only; factual language (`Score` not `Good/Bad`)
- **DR-005**: No CPF anywhere near frontend code